### PR TITLE
Possible Mono Compatible Version

### DIFF
--- a/Bugsnag.sln
+++ b/Bugsnag.sln
@@ -35,27 +35,38 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		MonoRelease|Any CPU = MonoRelease|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E73060E7-8BF3-43CE-B749-6F418C12EA5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E73060E7-8BF3-43CE-B749-6F418C12EA5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73060E7-8BF3-43CE-B749-6F418C12EA5B}.MonoRelease|Any CPU.ActiveCfg = MonoRelease|Any CPU
+		{E73060E7-8BF3-43CE-B749-6F418C12EA5B}.MonoRelease|Any CPU.Build.0 = MonoRelease|Any CPU
 		{E73060E7-8BF3-43CE-B749-6F418C12EA5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E73060E7-8BF3-43CE-B749-6F418C12EA5B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8185E14D-779D-486E-8827-F45EF6007F4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8185E14D-779D-486E-8827-F45EF6007F4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8185E14D-779D-486E-8827-F45EF6007F4B}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{8185E14D-779D-486E-8827-F45EF6007F4B}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{8185E14D-779D-486E-8827-F45EF6007F4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8185E14D-779D-486E-8827-F45EF6007F4B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{385DC263-2D7B-4C81-9154-AFA898DB3ED4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{385DC263-2D7B-4C81-9154-AFA898DB3ED4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{385DC263-2D7B-4C81-9154-AFA898DB3ED4}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{385DC263-2D7B-4C81-9154-AFA898DB3ED4}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{385DC263-2D7B-4C81-9154-AFA898DB3ED4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{385DC263-2D7B-4C81-9154-AFA898DB3ED4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0E890E8C-0F32-4C45-BAB8-26BF8748D1D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0E890E8C-0F32-4C45-BAB8-26BF8748D1D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E890E8C-0F32-4C45-BAB8-26BF8748D1D5}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{0E890E8C-0F32-4C45-BAB8-26BF8748D1D5}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{0E890E8C-0F32-4C45-BAB8-26BF8748D1D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E890E8C-0F32-4C45-BAB8-26BF8748D1D5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8539FD93-F93E-4F3B-ACC5-C0C665C7C02B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8539FD93-F93E-4F3B-ACC5-C0C665C7C02B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8539FD93-F93E-4F3B-ACC5-C0C665C7C02B}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{8539FD93-F93E-4F3B-ACC5-C0C665C7C02B}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{8539FD93-F93E-4F3B-ACC5-C0C665C7C02B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8539FD93-F93E-4F3B-ACC5-C0C665C7C02B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/src/Bugsnag.Core/Bugsnag.csproj
+++ b/src/Bugsnag.Core/Bugsnag.csproj
@@ -35,6 +35,17 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'MonoRelease|AnyCPU'">
+    <OutputPath>bin\MonoRelease\</OutputPath>
+    <DefineConstants>TRACE;MONO</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <AssemblyName>BugsnagMono</AssemblyName>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -45,7 +56,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Deployment" />
+    <Reference Include="System.Deployment" Condition="'$(Configuration)' != 'MonoRelease'" />
     <Reference Include="System.Management" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />

--- a/src/Bugsnag.Core/Clients/BaseClient.cs
+++ b/src/Bugsnag.Core/Clients/BaseClient.cs
@@ -168,19 +168,18 @@ namespace Bugsnag.Clients
 
                 // Set up some defaults for all clients
                 if (Debugger.IsAttached && String.IsNullOrEmpty(Config.ReleaseStage)) Config.ReleaseStage = "development";
-                if (String.IsNullOrEmpty(Config.AppVersion))
-                {
 #if !MONO
-                    if (System.Deployment.Application.ApplicationDeployment.IsNetworkDeployed)
-                    {
-                        // Use the application version defined for the Click-Once application, if it is one
-                        Config.AppVersion = System.Deployment.Application.ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString();
-                    }
+                // Use the application version defined for the Click-Once application, if it is one
+                if (String.IsNullOrEmpty(Config.AppVersion) && 
+                    System.Deployment.Application.ApplicationDeployment.IsNetworkDeployed)
+                {
+                    
+                    Config.AppVersion = System.Deployment.Application.ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString();
+                }
 #endif
-                    if (String.IsNullOrEmpty(Config.AppVersion) && Assembly.GetEntryAssembly() != null)
-                    {
-                        Config.AppVersion = Assembly.GetEntryAssembly().GetName().Version.ToString();
-                    }
+                if (String.IsNullOrEmpty(Config.AppVersion) && Assembly.GetEntryAssembly() != null)
+                {
+                    Config.AppVersion = Assembly.GetEntryAssembly().GetName().Version.ToString();
                 }
 
                 Initialized();

--- a/src/Bugsnag.Core/Clients/BaseClient.cs
+++ b/src/Bugsnag.Core/Clients/BaseClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Deployment.Application;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -171,12 +170,14 @@ namespace Bugsnag.Clients
                 if (Debugger.IsAttached && String.IsNullOrEmpty(Config.ReleaseStage)) Config.ReleaseStage = "development";
                 if (String.IsNullOrEmpty(Config.AppVersion))
                 {
-                    if (ApplicationDeployment.IsNetworkDeployed)
+#if !MONO
+                    if (System.Deployment.Application.ApplicationDeployment.IsNetworkDeployed)
                     {
                         // Use the application version defined for the Click-Once application, if it is one
-                        Config.AppVersion = ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString();
+                        Config.AppVersion = System.Deployment.Application.ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString();
                     }
-                    else if (Assembly.GetEntryAssembly() != null)
+#endif
+                    if (String.IsNullOrEmpty(Config.AppVersion) && Assembly.GetEntryAssembly() != null)
                     {
                         Config.AppVersion = Assembly.GetEntryAssembly().GetName().Version.ToString();
                     }


### PR DESCRIPTION
This is my attempt to make a Mono Compatible version. It basically has a MonoRelease configuration that will remove the incompatible code and references at compile time. It will build `BugsnagMono.dll` so you can tell the difference between the dlls.

I've excluded the incompatible code and reference mentioned in issue #19, but haven't got round to testing it so have no idea if there are any other places which are not compatible. Will try to test it on Mac at some point.