### PR TITLE
Aggregate exceptions + Inner Exception bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ error.Metadata.RemoveTab("Dev Only");
 ```
 
 ##### RemoveTabEntry
-Removes a tab that exists in the metadata.
+Removes a tab entry that exists in the metadata.
 
 ```c#
 // Removes the unit test result entry

--- a/src/Bugsnag.Core/NotificationFactory.cs
+++ b/src/Bugsnag.Core/NotificationFactory.cs
@@ -19,11 +19,12 @@ namespace Bugsnag
         public Notification CreateFromError(Event error)
         {
             var notification = CreateNotificationBase();
-            var eventInfo = CreateErrorEventInfo(error);
+            var eventInfo = CreateEventInfoBase(error);
+            RecursiveAddExceptionInfo(error, error.Exception, error.CallTrace, eventInfo);
             if (eventInfo == null)
                 return null;
 
-            notification.Events.AddRange(eventInfo);
+            notification.Events.Add(eventInfo);
             return notification;
         }
 
@@ -85,31 +86,20 @@ namespace Bugsnag
             return eventInfo;
         }
 
-        private List<EventInfo> CreateErrorEventInfo(Event error)
-        {
-            var baseEvent = CreateEventInfoBase(error);
-            var allEvents = new List<EventInfo> { baseEvent };
-            RecursiveAddExceptionInfo(error, error.Exception, error.CallTrace, allEvents, baseEvent);
-            return allEvents;
-        }
-
         /// <summary>
         /// Starting with an exception, will recursively add exception infos to event infos.
-        /// If an aggregate exception is encountered, an event info will be created for every inner exception
-        /// to ensure no information is lost.
+        /// If an aggregate exception is encountered, all inner exceptions will be added
         /// </summary>
         /// <param name="error">The error to create new event infos</param>
         /// <param name="exp">The exception to add to the current event</param>
         /// <param name="callStack">The stack of notify call</param>
-        /// <param name="allEventInfos">The current status of all event infos created</param>
         /// <param name="currentEvent">The current event info to add the exception to</param>
         private void RecursiveAddExceptionInfo(Event error,
                                                Exception exp,
                                                StackTrace callStack,
-                                               List<EventInfo> allEventInfos,
                                                EventInfo currentEvent)
         {
-            // If we have no more exceptions, return the generated event infos
+            // If we have no more exceptions, return the generated event info
             if (exp == null) return;
 
             // Parse the exception and add it to the current event info stack
@@ -126,23 +116,19 @@ namespace Bugsnag
             else
             {
                 // Check if the current exception contains more than 1 inner exception
-                // if it does, then clone new events for every inner exception and recurse through them seperately
+                // if it does, then recurse through them seperately
                 var aggExp = exp as AggregateException;
                 if (aggExp != null && aggExp.InnerExceptions.Count > 1)
                 {
-                    allEventInfos.Remove(currentEvent);
                     foreach (var inner in aggExp.InnerExceptions)
                     {
-                        var newEvent = CreateEventInfoBase(error);
-                        newEvent.Exceptions = new List<ExceptionInfo>(currentEvent.Exceptions);
-                        allEventInfos.Add(newEvent);
-                        RecursiveAddExceptionInfo(error, inner, callStack, allEventInfos, newEvent);
+                        RecursiveAddExceptionInfo(error, inner, callStack, currentEvent);
                     }
                 }
                 else
                 {
                     // Otherwise just move to the next inner exception
-                    RecursiveAddExceptionInfo(error, exp.InnerException, callStack, allEventInfos, currentEvent);
+                    RecursiveAddExceptionInfo(error, exp.InnerException, callStack, currentEvent);
                 }
             }
         }

--- a/test/Bugsnag.Core.Test/Bugsnag.Test.csproj
+++ b/test/Bugsnag.Core.Test/Bugsnag.Test.csproj
@@ -65,6 +65,8 @@
     <Compile Include="ExceptionParserTests.cs" />
     <Compile Include="EventTests.cs" />
     <Compile Include="FunctionalTests\BasicClientTests.cs" />
+    <Compile Include="FunctionalTests\ExceptionTypeTests.cs" />
+    <Compile Include="FunctionalTests\StaticData.cs" />
     <Compile Include="FunctionalTests\TestServer.cs" />
     <Compile Include="MetadataTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/Bugsnag.Core.Test/FunctionalTests/BasicClientTests.cs
+++ b/test/Bugsnag.Core.Test/FunctionalTests/BasicClientTests.cs
@@ -9,34 +9,15 @@ namespace Bugsnag.Test.FunctionalTests
 {
     public class BasicClientTests
     {
-        public const string TestApiKey = "ABCDEF1234567890ABCDEF1234567890";
-
-        public static readonly RankException TestException1;
-        public static readonly SystemException TestException2;
-
-        static BasicClientTests()
-        {
-            // Initialise test exceptions
-            try
-            {
-                throw new RankException("Rank Test");
-            }
-            catch (RankException e)
-            {
-                TestException1 = e;
-            }
-
-            TestException2 = new SystemException("System Test Exception");
-        }
-
         public static IEnumerable<object[]> ExceptionData
         {
             get
             {
                 return new[]
                 {
-                    new object[] {TestException1},
-                    new object[] {TestException2}
+                    new object[] {StaticData.TestThrowException},
+                    new object[] {StaticData.TestCreatedException},
+                    new object[] {StaticData.TestInnerException}
                 };
             }
         }
@@ -46,7 +27,7 @@ namespace Bugsnag.Test.FunctionalTests
         public void CheckBasicPropertiesOfNotifications(Exception exp)
         {
             // Arrange
-            var client = new BaseClient(TestApiKey);
+            var client = new BaseClient(StaticData.TestApiKey);
 
             // Act
             JObject json;
@@ -57,7 +38,7 @@ namespace Bugsnag.Test.FunctionalTests
             }
 
             // Assert
-            Assert.Equal(TestApiKey, json["apiKey"]);
+            Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
             Assert.Equal(Notifier.Name, json["notifier"]["name"]);
             Assert.Equal(Notifier.Version, json["notifier"]["version"]);
             Assert.Equal(Notifier.Url.AbsoluteUri, json["notifier"]["url"]);
@@ -67,13 +48,13 @@ namespace Bugsnag.Test.FunctionalTests
         public void DefaultSeverityForManuallyNotifiedExceptionsIsWarning()
         {
             // Arrange
-            var client = new BaseClient(TestApiKey);
+            var client = new BaseClient(StaticData.TestApiKey);
 
             // Act
             JObject json;
             using (var server = new TestServer(client))
             {
-                client.Notify(TestException1);
+                client.Notify(StaticData.TestThrowException);
                 json = server.GetLastResponse();
             }
 
@@ -88,13 +69,13 @@ namespace Bugsnag.Test.FunctionalTests
         public void SeveritySetManuallyIsUsedInTheNotification(Severity severity, string expJsonString)
         {
             // Arrange
-            var client = new BaseClient(TestApiKey);
+            var client = new BaseClient(StaticData.TestApiKey);
 
             // Act
             JObject json;
             using (var server = new TestServer(client))
             {
-                client.Notify(TestException1, severity);
+                client.Notify(StaticData.TestThrowException, severity);
                 json = server.GetLastResponse();
             }
 
@@ -106,7 +87,7 @@ namespace Bugsnag.Test.FunctionalTests
         public void AddSimpleMetadataToANotifications()
         {
             // Arrange
-            var client = new BaseClient(TestApiKey);
+            var client = new BaseClient(StaticData.TestApiKey);
             var testMetadata = new Metadata();
             testMetadata.AddToTab("Test Tab 1", "Key 1", "Value 1");
             testMetadata.AddToTab("Test Tab 1", "Key 2", "Value 2");
@@ -116,7 +97,7 @@ namespace Bugsnag.Test.FunctionalTests
             JObject json;
             using (var server = new TestServer(client))
             {
-                client.Notify(TestException1, testMetadata);
+                client.Notify(StaticData.TestThrowException, testMetadata);
                 json = server.GetLastResponse();
             }
 

--- a/test/Bugsnag.Core.Test/FunctionalTests/ExceptionTypeTests.cs
+++ b/test/Bugsnag.Core.Test/FunctionalTests/ExceptionTypeTests.cs
@@ -26,7 +26,6 @@ namespace Bugsnag.Test.FunctionalTests
             // Assert
             Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
 
-
             var traceJson = json["events"][0]["exceptions"][0]["stacktrace"];
             Assert.Equal(3, traceJson.Count());
             Assert.Equal("TestNamespace.ClassGamma.ThrowException()", traceJson[0]["method"]);

--- a/test/Bugsnag.Core.Test/FunctionalTests/ExceptionTypeTests.cs
+++ b/test/Bugsnag.Core.Test/FunctionalTests/ExceptionTypeTests.cs
@@ -83,20 +83,18 @@ namespace Bugsnag.Test.FunctionalTests
 
             // Assert
             Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
-            Assert.Equal(3, json["events"].Count());
+            Assert.Equal(1, json["events"].Count());
 
             // Check that 3 events are created, each having the Aggregate exception as the root exception
-            var task1Exps = json["events"].First(x => x["exceptions"][1]["errorClass"].Value<string>() == "FieldAccessException");
-            var task2Exps = json["events"].First(x => x["exceptions"][1]["errorClass"].Value<string>() == "StackOverflowException");
-            var task3Exps = json["events"].First(x => x["exceptions"][1]["errorClass"].Value<string>() == "AccessViolationException");
+            var task1Exps = json["events"][0]["exceptions"].First(x => x["errorClass"].Value<string>() == "FieldAccessException");
+            var task2Exps = json["events"][0]["exceptions"].First(x => x["errorClass"].Value<string>() == "StackOverflowException");
+            var task3Exps = json["events"][0]["exceptions"].First(x => x["errorClass"].Value<string>() == "AccessViolationException");
 
-            Assert.Equal("AggregateException", task1Exps["exceptions"][0]["errorClass"]);
-            Assert.Equal("AggregateException", task2Exps["exceptions"][0]["errorClass"]);
-            Assert.Equal("AggregateException", task3Exps["exceptions"][0]["errorClass"]);
+            Assert.Equal("AggregateException", json["events"][0]["exceptions"][0]["errorClass"]);
 
-            Assert.Equal("Task 1 Exception", task1Exps["exceptions"][1]["message"]);
-            Assert.Equal("Task 2 Exception", task2Exps["exceptions"][1]["message"]);
-            Assert.Equal("Task 3 Exception", task3Exps["exceptions"][1]["message"]);
+            Assert.Equal("Task 1 Exception", task1Exps["message"]);
+            Assert.Equal("Task 2 Exception", task2Exps["message"]);
+            Assert.Equal("Task 3 Exception", task3Exps["message"]);
         }
     }
 }

--- a/test/Bugsnag.Core.Test/FunctionalTests/ExceptionTypeTests.cs
+++ b/test/Bugsnag.Core.Test/FunctionalTests/ExceptionTypeTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Bugsnag.Clients;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Bugsnag.Test.FunctionalTests
+{
+    public class ExceptionTypeTests
+    {
+        [Fact]
+        public void CheckCallStacksAreReportedCorrectly()
+        {
+            // Arrange
+            var client = new BaseClient(StaticData.TestApiKey);
+
+            // Act
+            JObject json;
+            using (var server = new TestServer(client))
+            {
+                client.Notify(StaticData.TestCallStackException);
+                json = server.GetLastResponse();
+            }
+
+            // Assert
+            Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
+
+
+            var traceJson = json["events"][0]["exceptions"][0]["stacktrace"];
+            Assert.Equal(3, traceJson.Count());
+            Assert.Equal("TestNamespace.ClassGamma.ThrowException()", traceJson[0]["method"]);
+            Assert.Equal("TestNamespace.ClassBeta.ThrowException()", traceJson[1]["method"]);
+            Assert.Equal("TestNamespace.ClassAlpha.ThrowException()", traceJson[2]["method"]);
+        }
+
+        [Fact]
+        public void CheckInnerExceptionsAreNotified()
+        {
+            // Arrange
+            var client = new BaseClient(StaticData.TestApiKey);
+
+            // Act
+            JObject json;
+            using (var server = new TestServer(client))
+            {
+                client.Notify(StaticData.TestInnerException);
+                json = server.GetLastResponse();
+            }
+
+            // Assert
+            Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
+            Assert.Equal(3, json["events"][0]["exceptions"].Count());
+            Assert.Equal("ArithmeticException", json["events"][0]["exceptions"][0]["errorClass"]);
+            Assert.Equal("DivideByZeroException", json["events"][0]["exceptions"][1]["errorClass"]);
+            Assert.Equal("TypeAccessException", json["events"][0]["exceptions"][2]["errorClass"]);
+        }
+
+        [Fact]
+        public void CheckInnerExceptionsForBasicAggregateException()
+        {
+            // Arrange
+            var client = new BaseClient(StaticData.TestApiKey);
+            AggregateException testAggregateException = null;
+            var task1 = Task.Factory.StartNew(() => { throw new FieldAccessException("Task 1 Exception"); });
+            var task2 = Task.Factory.StartNew(() => { throw new StackOverflowException("Task 2 Exception"); });
+            var task3 = Task.Factory.StartNew(() => { throw new AccessViolationException("Task 3 Exception"); });
+            try
+            {
+                Task.WaitAll(task1, task2, task3);
+            }
+            catch (AggregateException ae)
+            {
+                testAggregateException = ae;
+            }
+
+            // Act
+            JObject json;
+            using (var server = new TestServer(client))
+            {
+                client.Notify(testAggregateException);
+                json = server.GetLastResponse();
+            }
+
+            // Assert
+            Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
+            Assert.Equal(3, json["events"].Count());
+
+            // Check that 3 events are created, each having the Aggregate exception as the root exception
+            var task1Exps = json["events"].First(x => x["exceptions"][1]["errorClass"].Value<string>() == "FieldAccessException");
+            var task2Exps = json["events"].First(x => x["exceptions"][1]["errorClass"].Value<string>() == "StackOverflowException");
+            var task3Exps = json["events"].First(x => x["exceptions"][1]["errorClass"].Value<string>() == "AccessViolationException");
+
+            Assert.Equal("AggregateException", task1Exps["exceptions"][0]["errorClass"]);
+            Assert.Equal("AggregateException", task2Exps["exceptions"][0]["errorClass"]);
+            Assert.Equal("AggregateException", task3Exps["exceptions"][0]["errorClass"]);
+
+            Assert.Equal("Task 1 Exception", task1Exps["exceptions"][1]["message"]);
+            Assert.Equal("Task 2 Exception", task2Exps["exceptions"][1]["message"]);
+            Assert.Equal("Task 3 Exception", task3Exps["exceptions"][1]["message"]);
+        }
+    }
+}

--- a/test/Bugsnag.Core.Test/FunctionalTests/StaticData.cs
+++ b/test/Bugsnag.Core.Test/FunctionalTests/StaticData.cs
@@ -1,0 +1,100 @@
+﻿using System;
+
+namespace Bugsnag.Test.FunctionalTests
+{
+    /// <summary>
+    /// Contains static data used in functional tests
+    /// </summary>
+    public static class StaticData
+    {
+        public const string TestApiKey = "ABCDEF1234567890ABCDEF1234567890";
+
+        // Custom created exceptions used for testing
+        public static readonly SystemException TestCreatedException;
+        public static readonly RankException TestThrowException;
+        public static readonly ArithmeticException TestInnerException;
+        public static readonly TimeoutException TestCallStackException;
+
+        static StaticData()
+        {
+            // Exception created but is not thrown
+            TestCreatedException = new SystemException("System Test Exception");
+
+            // Traditional created and throw exception
+            try
+            {
+                throw new RankException("Rank Test");
+            }
+            catch (RankException e)
+            {
+                TestThrowException = e;
+            }
+
+            // Exception containing inner exceptions
+            try
+            {
+                try
+                {
+                    try
+                    {
+                        throw new TypeAccessException("Test Type Exception");
+                    }
+                    catch (TypeAccessException exp1)
+                    {
+                        throw new DivideByZeroException("Divide By Zero Test", exp1);
+                    }
+                }
+                catch (DivideByZeroException exp2)
+                {
+                    throw new ArithmeticException("Inner Exception Test", exp2);
+                }
+            }
+            catch (ArithmeticException exp3)
+            {
+                TestInnerException = exp3;
+            }
+
+            // Exception with a defined stack trace
+            var callClass = new TestNamespace.ClassAlpha();
+            try
+            {
+                callClass.ThrowException();
+            }
+            catch (TimeoutException exp)
+            {
+                TestCallStackException = exp;
+            }
+        }
+    }
+}
+
+// Create a custom namespace so that the associated call stack is not identified
+// as a Bugsnag related frame
+namespace TestNamespace
+{
+    public class ClassAlpha
+    {
+        public void ThrowException()
+        {
+            var beta = new ClassBeta();
+            beta.ThrowException();
+        }
+    }
+
+    public class ClassBeta
+    {
+        public void ThrowException()
+        {
+            var gamma = new ClassGamma();
+            gamma.ThrowException();
+        }
+    }
+
+    public class ClassGamma
+    {
+        public void ThrowException()
+        {
+            throw new TimeoutException("Test Timeout Exception");
+        }
+    }
+}


### PR DESCRIPTION
An aggregate exception can have multiple inner exceptions. But any of these inner exceptions can be aggregate exceptions themselves. This branching behavior is hard to represent in the current Bugsnag UI, so I've done a fix that end ups generating a new Event whenever this type of branching occurs. 

This isn't ideal but at least records information about every exception generated. The only downside is that its not obvious that two events were created from same Aggregate Exception. Any suggestions on how to represent it in the UI?

Also noticed a bug with displaying inner exceptions...they weren't, they were just copies of the original 
[(link to line)](https://github.com/bugsnag/bugsnag-dotnet/blob/master/src/Bugsnag.Core/NotificationFactory.cs#L132) should be `ExceptionParser.GenerateExceptionInfo(currentExp, ...`.

But since I've rewrote that section for this fix, its not a problem here.

Also added some black box testing for some Exception types to cover these types of exceptions
