### PR TITLE
Marchello2000/noexceptionleaks

### DIFF
--- a/src/Bugsnag/Clients/BaseClient.cs
+++ b/src/Bugsnag/Clients/BaseClient.cs
@@ -5,6 +5,10 @@ using System.Text.RegularExpressions;
 using Bugsnag.ConfigurationStorage;
 using Bugsnag.Handlers;
 
+#if !NET35
+using System.Threading.Tasks;
+#endif
+
 namespace Bugsnag.Clients
 {
     /// <summary>
@@ -158,6 +162,41 @@ namespace Bugsnag.Clients
 
             notifier.Send(errorEvent);
         }
+
+#if !NET35
+        // Async variants of the Notify functions above
+        public Task NotifyAsync(Exception error)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Notify(error);
+                });
+        }
+
+        public Task NotifyAsync(Exception error, Metadata metadata)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Notify(error, metadata);
+                });
+        }
+
+        public Task NotifyAsync(Exception error, Severity severity)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Notify(error, severity);
+                });
+        }
+
+        public Task NotifyAsync(Exception error, Severity severity, Metadata metadata)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Notify(error, severity, metadata);
+                });
+        }
+#endif
 
         /// <summary>
         /// Initialize the client with dependencies

--- a/src/Bugsnag/Clients/BaseClient.cs
+++ b/src/Bugsnag/Clients/BaseClient.cs
@@ -77,7 +77,7 @@ namespace Bugsnag.Clients
         {
             unhandledExceptionHandler.UninstallHandler();
 #if !NET35
-            taskExceptionHandler.InstallHandler(HandleDefaultException);
+            taskExceptionHandler.UninstallHandler();
 #endif
         }
 

--- a/src/Bugsnag/Clients/SingletonBaseClient.cs
+++ b/src/Bugsnag/Clients/SingletonBaseClient.cs
@@ -1,5 +1,10 @@
 ﻿using System;
 
+#if !NET35
+// Tasks for Async versions of Notify()
+using System.Threading.Tasks;
+#endif
+
 namespace Bugsnag.Clients
 {
     public static class SingletonBaseClient
@@ -68,5 +73,28 @@ namespace Bugsnag.Clients
         {
             Client.Notify(errorEvent);
         }
+
+#if !NET35
+        // Async variants of Notify() methods above
+        public static Task NotifyAsync(Exception error)
+        {
+            return Client.NotifyAsync(error);
+        }
+
+        public static Task NotifyAsync(Exception error, Severity severity)
+        {
+            return Client.NotifyAsync(error, severity);
+        }
+
+        public static Task NotifyAsync(Exception error, Metadata data)
+        {
+            return Client.NotifyAsync(error, data);
+        }
+
+        public static Task NotifyAsync(Exception error, Severity severity, Metadata data)
+        {
+            return Client.NotifyAsync(error, severity, data);
+        }
+#endif
     }
 }

--- a/src/Bugsnag/Clients/WPFClient.cs
+++ b/src/Bugsnag/Clients/WPFClient.cs
@@ -2,6 +2,10 @@
 using System.Linq;
 using System.Windows;
 
+#if !NET35
+using System.Threading.Tasks;
+#endif
+
 namespace Bugsnag.Clients
 {
     public static class WPFClient
@@ -47,5 +51,31 @@ namespace Bugsnag.Clients
         {
             Client.Notify(error, severity, metadata);
         }
+
+#if !NET35
+        public static Task NotifyAsync(Exception error, Metadata metadata)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Client.Notify(error, metadata);
+                });
+        }
+
+        public static Task NotifyAsync(Exception error, Severity severity)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Client.Notify(error, severity);
+                });
+        }
+
+        public static Task NotifyAsync(Exception error, Severity severity, Metadata metadata)
+        {
+            return Task.Factory.StartNew(() =>
+                {
+                    Client.Notify(error, severity, metadata);
+                });
+        }
+#endif
     }
 }

--- a/src/Bugsnag/Clients/WPFClient.cs
+++ b/src/Bugsnag/Clients/WPFClient.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 
 #if !NET35
+// Tasks for Async versions of Notify()
 using System.Threading.Tasks;
 #endif
 
@@ -53,28 +54,24 @@ namespace Bugsnag.Clients
         }
 
 #if !NET35
+        public static Task NotifyAsync(Exception error)
+        {
+            return Client.NotifyAsync(error);
+        }
+
         public static Task NotifyAsync(Exception error, Metadata metadata)
         {
-            return Task.Factory.StartNew(() =>
-                {
-                    Client.Notify(error, metadata);
-                });
+            return Client.NotifyAsync(error, metadata);
         }
 
         public static Task NotifyAsync(Exception error, Severity severity)
         {
-            return Task.Factory.StartNew(() =>
-                {
-                    Client.Notify(error, severity);
-                });
+            return Client.NotifyAsync(error, severity);
         }
 
         public static Task NotifyAsync(Exception error, Severity severity, Metadata metadata)
         {
-            return Task.Factory.StartNew(() =>
-                {
-                    Client.Notify(error, severity, metadata);
-                });
+            return Client.NotifyAsync(error, severity, metadata);
         }
 #endif
     }

--- a/src/Bugsnag/Clients/WebMVCClient.cs
+++ b/src/Bugsnag/Clients/WebMVCClient.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Web;
 
-// Provide exception attribute for global filters (> .NET 4.0 )
 #if !NET35
+// Tasks for Async versions of Notify()
+using System.Threading.Tasks;
+
+// Provide exception attribute for global filters (> .NET 4.0 )
 using System.Web.Mvc;
 #endif
 
@@ -78,6 +81,28 @@ namespace Bugsnag.Clients
         {
             Client.Notify(error, severity, metadata);
         }
+
+#if !NET35
+        public static Task NotifyAsync(Exception error)
+        {
+            return Client.NotifyAsync(error);
+        }
+
+        public static Task NotifyAsync(Exception error, Metadata metadata)
+        {
+            return Client.NotifyAsync(error, metadata);
+        }
+
+        public static Task NotifyAsync(Exception error, Severity severity)
+        {
+            return Client.NotifyAsync(error, severity);
+        }
+
+        public static Task NotifyAsync(Exception error, Severity severity, Metadata metadata)
+        {
+            return Client.NotifyAsync(error, severity, metadata);
+        }
+#endif
 
 #if !NET35
         /// <summary>

--- a/src/Bugsnag/Notifier.cs
+++ b/src/Bugsnag/Notifier.cs
@@ -58,8 +58,10 @@ namespace Bugsnag
                 }
                 request.GetResponse().Close();
             }
-            catch
+            catch (Exception e)
             {
+                Logger.Warning("Bugsnag failed to send error report with exception: " + e.ToString());
+
                 // Deliberate empty catch for now
 
                 // Must never double fault - i.e. can't leak an exception from an exception handler

--- a/src/Bugsnag/Notifier.cs
+++ b/src/Bugsnag/Notifier.cs
@@ -41,20 +41,35 @@ namespace Bugsnag
 
         private void Send(Notification notification)
         {
-            //  Post JSON to server:
-            var request = WebRequest.Create(Config.EndpointUrl);
-
-            request.Method = WebRequestMethods.Http.Post;
-            request.ContentType = "application/json";
-            request.Proxy = DetectedProxy;
-
-            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
+            try
             {
-                string json = JsonConvert.SerializeObject(notification, JsonSettings);
-                streamWriter.Write(json);
-                streamWriter.Flush();
+                //  Post JSON to server:
+                var request = WebRequest.Create(Config.EndpointUrl);
+
+                request.Method = WebRequestMethods.Http.Post;
+                request.ContentType = "application/json";
+                request.Proxy = DetectedProxy;
+
+                using (var streamWriter = new StreamWriter(request.GetRequestStream()))
+                {
+                    string json = JsonConvert.SerializeObject(notification, JsonSettings);
+                    streamWriter.Write(json);
+                    streamWriter.Flush();
+                }
+                request.GetResponse().Close();
             }
-            request.GetResponse().Close();
+            catch
+            {
+                // Deliberate empty catch for now
+
+                // Must never double fault - i.e. can't leak an exception from an exception handler
+                // Also the caller might have just wanted to report an "information" bugsnag and we
+                // certainly don't want to fault then
+
+                // However, "offline" handling should be addressed. I.e. bugsnags should be queued
+                // until network is available and sent then, see
+                // https://github.com/bugsnag/bugsnag-dotnet/issues/31
+            }
         }
     }
 }

--- a/test/Bugsnag.Test/FunctionalTests/BasicClientTests.cs
+++ b/test/Bugsnag.Test/FunctionalTests/BasicClientTests.cs
@@ -107,5 +107,27 @@ namespace Bugsnag.Test.FunctionalTests
             Assert.Equal("Value 2", actData["Test Tab 1"]["Key 2"]);
             Assert.Equal("Value 1", actData["Test Tab 2"]["Key 1"]);
         }
+
+        [Fact]
+        public void TestNoExceptionLeaks()
+        {
+            // Arrange
+            var client = new BaseClient(StaticData.TestApiKey);
+
+            // Act
+            using (var server = new TestServer(client))
+            {
+                server.Stop();
+                try
+                {
+                    client.Notify(StaticData.TestThrowException);
+                }
+                catch (Exception e)
+                {
+                    // Assert
+                    Assert.True(false, "No network shouldn't throw: " + e.ToString());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Don't leak out exceptions from the exception handler (sender)

Properly uninstall the TaskException handler

Adding Async variants of the Notify() methods, since informational bugsnags shouldn't block the main application