### PR TITLE
Removed base.OnException() call from MVC client

### DIFF
--- a/src/Bugsnag/Clients/WebMVCClient.cs
+++ b/src/Bugsnag/Clients/WebMVCClient.cs
@@ -117,9 +117,9 @@ namespace Bugsnag.Clients
 
             public override void OnException(ExceptionContext filterContext)
             {
-                base.OnException(filterContext);
                 if (filterContext == null || filterContext.Exception == null)
                     return;
+
                 if (Config.AutoNotify)
                     Client.Notify(filterContext.Exception);
             }


### PR DESCRIPTION
Fixes issues #41 

Stops attempting to render a Error page as part of the Bugsnag Client, will just report the exception. 

Note that the exception show now not be marked as handled.