### PR TITLE
Detects Windows 10 if added to the app manifest

### DIFF
--- a/src/Bugsnag/Diagnostics.cs
+++ b/src/Bugsnag/Diagnostics.cs
@@ -160,6 +160,8 @@ namespace Bugsnag
                         }
                     }
                     return "UNKNOWN";
+                case 10:
+                    return "Windows 10";
                 default:
                     return "UNKNOWN";
             }


### PR DESCRIPTION
Only works if app manifest includes supported OS