### PR TITLE
Set standard severity for MVC applications

### DIFF
--- a/src/Bugsnag/Clients/WebMVCClient.cs
+++ b/src/Bugsnag/Clients/WebMVCClient.cs
@@ -121,7 +121,7 @@ namespace Bugsnag.Clients
                     return;
 
                 if (Config.AutoNotify)
-                    Client.Notify(filterContext.Exception);
+                    Client.Notify(filterContext.Exception, Severity.Error);
             }
         }
 


### PR DESCRIPTION
Right now, unhandled exceptions on MVC applications seem to be coming through as warnings. We should be setting those as errors.