### PR TITLE
Offline support

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -24,7 +24,7 @@ Target "RestorePackages" (fun _ ->
 )
 
 Target "Clean" (fun _ ->
-  showGitCommand "." "clean -xdf --exclude=packages"
+  showGitCommand "." "clean -xdf src"
   CleanDir buildDir
 )
 

--- a/src/Bugsnag/Bugsnag.Net35.csproj
+++ b/src/Bugsnag/Bugsnag.Net35.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\Common\CommonVersionInfo.cs">
       <Link>Properties\CommonVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="OfflineStore.cs" />
     <Compile Include="Clients\BaseClient.cs" />
     <Compile Include="Clients\SingletonBaseClient.cs" />
     <Compile Include="Clients\WebMVCClient.cs" />

--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -81,6 +81,7 @@
       <Link>Properties\CommonVersionInfo.cs</Link>
     </Compile>
     <Compile Include="Handlers\UnhandledExceptionHandler.cs" />
+    <Compile Include="OfflineStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Clients\SingletonBaseClient.cs" />
     <Compile Include="Clients\BaseClient.cs" />

--- a/src/Bugsnag/Clients/BaseClient.cs
+++ b/src/Bugsnag/Clients/BaseClient.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Bugsnag.ConfigurationStorage;
 using Bugsnag.Handlers;
+using System.Threading;
 
 #if !NET35
 using System.Threading.Tasks;
@@ -213,6 +214,11 @@ namespace Bugsnag.Clients
             {
                 Config = new Configuration(configStorage);
                 notifier = new Notifier(Config);
+
+                if (Config.StoreOfflineErrors)
+                {
+                    ThreadPool.QueueUserWorkItem(e => { notifier.SendStoredReports(); });
+                }
 
                 // Install a default exception handler with this client
                 if (Config.AutoNotify)

--- a/src/Bugsnag/Clients/BaseClient.cs
+++ b/src/Bugsnag/Clients/BaseClient.cs
@@ -257,7 +257,7 @@ namespace Bugsnag.Clients
             Notify(error);
         }
 
-        public void SendStoredExceptions()
+        public void SendStoredReports()
         {
             notifier.SendStoredReports();
         }

--- a/src/Bugsnag/Clients/BaseClient.cs
+++ b/src/Bugsnag/Clients/BaseClient.cs
@@ -256,5 +256,10 @@ namespace Bugsnag.Clients
             var error = new Event(exception, runtimeEnding);
             Notify(error);
         }
+
+        public void SendStoredExceptions()
+        {
+            notifier.SendStoredReports();
+        }
     }
 }

--- a/src/Bugsnag/Clients/WPFClient.cs
+++ b/src/Bugsnag/Clients/WPFClient.cs
@@ -33,6 +33,11 @@ namespace Bugsnag.Clients
 
         }
 
+        public static void SendStoredReports()
+        {
+            Client.SendStoredExceptions();
+        }
+
         public static void Notify(Exception error)
         {
             Client.Notify(error);

--- a/src/Bugsnag/Clients/WPFClient.cs
+++ b/src/Bugsnag/Clients/WPFClient.cs
@@ -35,7 +35,7 @@ namespace Bugsnag.Clients
 
         public static void SendStoredReports()
         {
-            Client.SendStoredExceptions();
+            Client.SendStoredReports();
         }
 
         public static void Notify(Exception error)

--- a/src/Bugsnag/Configuration.cs
+++ b/src/Bugsnag/Configuration.cs
@@ -155,6 +155,12 @@ namespace Bugsnag
             get { return Storage.MetadataFilters; }
             set { Storage.MetadataFilters = value; }
         }
+
+        public bool StoreOfflineErrors
+        {
+            get { return Storage.StoreOfflineErrors; }
+            set { Storage.StoreOfflineErrors = value; }
+        }
         #endregion
 
         /// <summary>

--- a/src/Bugsnag/ConfigurationStorage/BaseStorage.cs
+++ b/src/Bugsnag/ConfigurationStorage/BaseStorage.cs
@@ -1,4 +1,6 @@
-﻿namespace Bugsnag.ConfigurationStorage
+﻿using System;
+
+namespace Bugsnag.ConfigurationStorage
 {
     public class BaseStorage : IConfigurationStorage
     {
@@ -83,6 +85,8 @@
         /// </summary>
         public string[] MetadataFilters { get; set; }
 
+        public bool StoreOfflineErrors { get; set; }
+
         /// <summary>
         /// Constructor for the BaseStorage class. ConfigurationStorage classes deal with storing and
         /// retrieving configuration variables for the Bugsnag notifier.
@@ -98,6 +102,7 @@
             MetadataFilters = new string[] { };
             ProjectNamespaces = new string[] { };
             FilePrefixes = new string[] { };
+            StoreOfflineErrors = false;
         }
     }
 }

--- a/src/Bugsnag/ConfigurationStorage/ConfigSection.cs
+++ b/src/Bugsnag/ConfigurationStorage/ConfigSection.cs
@@ -251,5 +251,24 @@ namespace Bugsnag.ConfigurationStorage
             }
             set { this._metadataFilters = value; }
         }
+
+        private bool? _storeOfflineErrors;
+        [ConfigurationProperty("storeOfflineErrors", IsRequired = false, DefaultValue = false)]
+        public bool StoreOfflineErrors
+        {
+            get
+            {
+                if (this._storeOfflineErrors.HasValue)
+                {
+                    return this._storeOfflineErrors.Value;
+                }
+                else
+                {
+                    this._storeOfflineErrors = (bool?)this["storeOfflineErrors"];
+                    return this._storeOfflineErrors.HasValue ? this._storeOfflineErrors.Value : false;
+                }
+            }
+            set { this._storeOfflineErrors = value; }
+        }
     }
 }

--- a/src/Bugsnag/ConfigurationStorage/IConfigurationStorage.cs
+++ b/src/Bugsnag/ConfigurationStorage/IConfigurationStorage.cs
@@ -82,5 +82,6 @@
         /// prevent sensitive information being sent to Bugsnag.
         /// </summary>
         string[] MetadataFilters { get; set; }
+        bool StoreOfflineErrors { get; set; }
     }
 }

--- a/src/Bugsnag/Notifier.cs
+++ b/src/Bugsnag/Notifier.cs
@@ -44,9 +44,16 @@ namespace Bugsnag
 
         public void SendStoredReports()
         {
-            foreach (var storedReport in Store.ReadStoredJson())
+            try
             {
-                SendJson(storedReport);
+                foreach (var storedReport in Store.ReadStoredJson())
+                {
+                    SendJson(storedReport);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Warning(string.Format("Bugsnag failed to send persisted error reports with exception: {0}", e.ToString()));
             }
         }
 
@@ -91,7 +98,14 @@ namespace Bugsnag
             }
             if (!reportSent)
             {
-                Store.StoreJson(json);
+                try
+                {
+                    Store.StoreJson(json);
+                }
+                catch (Exception e)
+                {
+                    Logger.Warning("Bugsnag failed to persist error report with exception: " + e.ToString());
+                }
             }
         }
     }

--- a/src/Bugsnag/Notifier.cs
+++ b/src/Bugsnag/Notifier.cs
@@ -96,7 +96,7 @@ namespace Bugsnag
             {
                 Logger.Warning("Bugsnag failed to send error report with exception: " + e.ToString());
             }
-            if (!reportSent)
+            if (!reportSent && Config.StoreOfflineErrors)
             {
                 try
                 {

--- a/src/Bugsnag/Notifier.cs
+++ b/src/Bugsnag/Notifier.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Reflection;
 using Bugsnag.Payload;
 using Newtonsoft.Json;
+using System.IO.IsolatedStorage;
 
 namespace Bugsnag
 {
@@ -25,11 +26,13 @@ namespace Bugsnag
 
         private Configuration Config { get; set; }
         private NotificationFactory Factory { get; set; }
+        private OfflineStore Store { get; set; }
 
         public Notifier(Configuration config)
         {
             Config = config;
             Factory = new NotificationFactory(config);
+            Store = new OfflineStore();
         }
 
         public void Send(Event errorEvent)
@@ -39,8 +42,29 @@ namespace Bugsnag
                 Send(notification);
         }
 
+        public void SendStoredReports()
+        {
+            foreach (var storedReport in Store.ReadStoredJson())
+            {
+                SendJson(storedReport);
+            }
+        }
+
         private void Send(Notification notification)
         {
+            try
+            {
+                SendJson(JsonConvert.SerializeObject(notification, JsonSettings));
+            }
+            catch (Exception e)
+            {
+                Logger.Warning(string.Format("Bugsnag failed to serialise error report with exception: {0}", e.ToString()));
+            }
+        }
+
+        private void SendJson(string json)
+        {
+            var reportSent = false;
             try
             {
                 //  Post JSON to server:
@@ -52,25 +76,22 @@ namespace Bugsnag
 
                 using (var streamWriter = new StreamWriter(request.GetRequestStream()))
                 {
-                    string json = JsonConvert.SerializeObject(notification, JsonSettings);
                     streamWriter.Write(json);
                     streamWriter.Flush();
                 }
-                request.GetResponse().Close();
+
+                using (request.GetResponse())
+                {
+                }
+                reportSent = true;
             }
             catch (Exception e)
             {
                 Logger.Warning("Bugsnag failed to send error report with exception: " + e.ToString());
-
-                // Deliberate empty catch for now
-
-                // Must never double fault - i.e. can't leak an exception from an exception handler
-                // Also the caller might have just wanted to report an "information" bugsnag and we
-                // certainly don't want to fault then
-
-                // However, "offline" handling should be addressed. I.e. bugsnags should be queued
-                // until network is available and sent then, see
-                // https://github.com/bugsnag/bugsnag-dotnet/issues/31
+            }
+            if (!reportSent)
+            {
+                Store.StoreJson(json);
             }
         }
     }

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -11,7 +11,7 @@ namespace Bugsnag
 
         internal IEnumerable<string> ReadStoredJson()
         {
-            using (var store = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null))
+            using (var store = IsolatedStorageFile())
             {
                 store.CreateDirectory("crash_reports");
                 foreach (var filePath in store.GetFileNames("crash_reports\\*"))
@@ -28,7 +28,7 @@ namespace Bugsnag
 
         internal void StoreJson(string json)
         {
-            using (var store = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null))
+            using (var store = IsolatedStorageFile())
             {
                 store.CreateDirectory("crash_reports");
                 using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}.json", Guid.NewGuid()), FileMode.CreateNew, store))
@@ -62,6 +62,11 @@ namespace Bugsnag
             }
 
             return fileData;
+        }
+
+        private static IsolatedStorageFile IsolatedStorageFile()
+        {
+            return System.IO.IsolatedStorage.IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null);
         }
     }
 }

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -19,7 +19,7 @@ namespace Bugsnag
 
                     lock (_lock)
                     {
-                        using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, FileAccess.Read, FileShare.Read, 512, store))
+                        using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, store))
                         {
                             var reader = new StreamReader(storageStream);
                             fileData = reader.ReadToEnd();

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -19,10 +19,17 @@ namespace Bugsnag
 
                     lock (_lock)
                     {
-                        using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, store))
+                        try
                         {
-                            var reader = new StreamReader(storageStream);
-                            fileData = reader.ReadToEnd();
+                            using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, store))
+                            {
+                                var reader = new StreamReader(storageStream);
+                                fileData = reader.ReadToEnd();
+                            }
+                        }
+                        catch (FileNotFoundException)
+                        {
+                            // we can assume here that this crash report has already been sent in another thread
                         }
                         store.DeleteFile(string.Format("crash_reports\\{0}", filePath));
                     }

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -74,7 +74,14 @@ namespace Bugsnag
 
         private static IsolatedStorageFile IsolatedStorageFile()
         {
-            return System.IO.IsolatedStorage.IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null);
+            if (AppDomain.CurrentDomain != null && AppDomain.CurrentDomain.ActivationContext != null)
+            {
+                return System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForApplication();
+            }
+            else
+            {
+                return System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForAssembly();
+            }
         }
     }
 }

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -13,6 +13,7 @@ namespace Bugsnag
         {
             using (var store = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null))
             {
+                store.CreateDirectory("crash_reports");
                 foreach (var filePath in store.GetFileNames("crash_reports\\*"))
                 {
                     string fileData = ReadAndRemoveCrashReport(store, filePath);

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.IsolatedStorage;
+
+namespace Bugsnag
+{
+    internal class OfflineStore
+    {
+        private static object _lock = new object();
+
+        internal IEnumerable<string> ReadStoredJson()
+        {
+            using (var store = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null))
+            {
+                foreach (var filePath in store.GetFileNames("crash_reports\\*"))
+                {
+                    string fileData = null;
+
+                    lock (_lock)
+                    {
+                        using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, FileAccess.Read, FileShare.Read, 512, store))
+                        {
+                            var reader = new StreamReader(storageStream);
+                            fileData = reader.ReadToEnd();
+                        }
+                        store.DeleteFile(string.Format("crash_reports\\{0}", filePath));
+                    }
+
+                    if (fileData != null)
+                    {
+                        yield return fileData;
+                    }
+                }
+            }
+        }
+
+        internal void StoreJson(string json)
+        {
+            using (var store = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null))
+            {
+                store.CreateDirectory("crash_reports");
+                using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}.json", Guid.NewGuid()), FileMode.CreateNew, store))
+                {
+                    var writer = new StreamWriter(storageStream);
+                    writer.Write(json);
+                    writer.Flush();
+                }
+            }
+        }
+    }
+}

--- a/src/Bugsnag/OfflineStore.cs
+++ b/src/Bugsnag/OfflineStore.cs
@@ -15,24 +15,7 @@ namespace Bugsnag
             {
                 foreach (var filePath in store.GetFileNames("crash_reports\\*"))
                 {
-                    string fileData = null;
-
-                    lock (_lock)
-                    {
-                        try
-                        {
-                            using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, store))
-                            {
-                                var reader = new StreamReader(storageStream);
-                                fileData = reader.ReadToEnd();
-                            }
-                        }
-                        catch (FileNotFoundException)
-                        {
-                            // we can assume here that this crash report has already been sent in another thread
-                        }
-                        store.DeleteFile(string.Format("crash_reports\\{0}", filePath));
-                    }
+                    string fileData = ReadAndRemoveCrashReport(store, filePath);
 
                     if (fileData != null)
                     {
@@ -54,6 +37,30 @@ namespace Bugsnag
                     writer.Flush();
                 }
             }
+        }
+
+        private string ReadAndRemoveCrashReport(IsolatedStorageFile store, string filePath)
+        {
+            string fileData = null;
+
+            lock (_lock)
+            {
+                try
+                {
+                    using (var storageStream = new IsolatedStorageFileStream(string.Format("crash_reports\\{0}", filePath), FileMode.Open, store))
+                    {
+                        var reader = new StreamReader(storageStream);
+                        fileData = reader.ReadToEnd();
+                    }
+                }
+                catch (FileNotFoundException)
+                {
+                    // we can assume here that this crash report has already been sent in another thread
+                }
+                store.DeleteFile(string.Format("crash_reports\\{0}", filePath));
+            }
+
+            return fileData;
         }
     }
 }

--- a/test/FunctionalTests/BasicClientTests.cs
+++ b/test/FunctionalTests/BasicClientTests.cs
@@ -28,6 +28,7 @@ namespace Bugsnag.Test.FunctionalTests
         {
             var client = new BaseClient(StaticData.TestApiKey);
             client.Config.Endpoint = "http://localhost:8181/";
+            client.Config.StoreOfflineErrors = true;
 
             client.Notify(exp);
 
@@ -39,6 +40,7 @@ namespace Bugsnag.Test.FunctionalTests
                 json = server.GetLastResponse();
             }
 
+            Assert.NotNull(json);
             Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
             Assert.Equal(Notifier.Name, json["notifier"]["name"]);
             Assert.Equal(Notifier.Version, json["notifier"]["version"]);

--- a/test/FunctionalTests/BasicClientTests.cs
+++ b/test/FunctionalTests/BasicClientTests.cs
@@ -24,6 +24,29 @@ namespace Bugsnag.Test.FunctionalTests
 
         [Theory]
         [PropertyData("ExceptionData")]
+        public void CheckOfflineStorage(Exception exp)
+        {
+            var client = new BaseClient(StaticData.TestApiKey);
+            client.Config.Endpoint = "http://localhost:8181/";
+
+            client.Notify(exp);
+
+            JObject json;
+
+            using (var server = new TestServer(client))
+            {
+                client.notifier.SendStoredReports();
+                json = server.GetLastResponse();
+            }
+
+            Assert.Equal(StaticData.TestApiKey, json["apiKey"]);
+            Assert.Equal(Notifier.Name, json["notifier"]["name"]);
+            Assert.Equal(Notifier.Version, json["notifier"]["version"]);
+            Assert.Equal(Notifier.Url.AbsoluteUri, json["notifier"]["url"]);
+        }
+
+        [Theory]
+        [PropertyData("ExceptionData")]
         public void CheckBasicPropertiesOfNotifications(Exception exp)
         {
             // Arrange


### PR DESCRIPTION
This PR allows you to store error reports if they fail to send in IsolatedStorage if the configuration option is set.

If this configuration option is set, then when the Client is started it will attempt to send any stored error reports in a separate thread.