### PR TITLE
Change Logger to write to windows EventLog as well

### DIFF
--- a/src/Bugsnag/Logger.cs
+++ b/src/Bugsnag/Logger.cs
@@ -7,6 +7,14 @@ namespace Bugsnag
     /// </summary>
     internal static class Logger
     {
+        /// <remarks>
+        /// The EventLog and EventLog.Source are usually different, but specifying a custom source (like "Bugsnag")
+        /// requires administrative priviledges to setup before it can be used. Using an existing source --
+        /// like "Application", which should always already exist -- side steps the issue. See
+        /// http://stackoverflow.com/a/27640623/1462295
+        /// </remarks>
+        private const string EventLogSource = "Application";
+
         /// <summary>
         /// Record an informational message
         /// </summary>
@@ -14,6 +22,8 @@ namespace Bugsnag
         public static void Info(string message)
         {
             Debug.WriteLine("[INFO] " + message, "bugsnag");
+
+            EventLogMessage(message, EventLogEntryType.Information);
         }
 
         /// <summary>
@@ -23,6 +33,8 @@ namespace Bugsnag
         public static void Warning(string message)
         {
             Debug.WriteLine("[WARN] " + message, "bugsnag");
+
+            EventLogMessage(message, EventLogEntryType.Warning);
         }
 
         /// <summary>
@@ -32,6 +44,31 @@ namespace Bugsnag
         public static void Error(string message)
         {
             Debug.WriteLine("[ERROR] " + message, "bugsnag");
+
+            EventLogMessage(message, EventLogEntryType.Error);
+        }
+
+        /// <summary>
+        /// Helper method to write unhandled Bugsnag error to Windows event log.
+        /// </summary>
+        /// <param name="message">Message to write to the event log.</param>
+        /// <param name="entryType">Severity of message to write.</param>
+        private static void EventLogMessage(string message, EventLogEntryType entryType)
+        {
+            try
+            {
+                using (EventLog eventLog = new EventLog(EventLogSource))
+                {
+                    // Source name may be truncated at 21 characters, or may possibly fail if longer than 21 characters.
+                    // See comments at https://msdn.microsoft.com/en-us/library/windows/desktop/aa363661%28v=vs.85%29.aspx
+                    eventLog.Source = EventLogSource;
+                    eventLog.WriteEntry(message, entryType);
+                }
+            }
+            catch
+            {
+                Debug.WriteLine("[ERROR] Could not write to EventLog.", "bugsnag");
+            }
         }
     }
 }


### PR DESCRIPTION
As far as I can tell, if something goes wrong with Bugsnag the only output is via `Debug.WriteLine`. Ideally there would be some kind of logging mechanism with configuration options in the app/web.config (e.g., write to file). I chose a simpler solution, which is writing to the Windows EventLog. This has its own limitations, such as not being able to specify the source in a useful way because that requires a setup procedure with admin privileges (to clarify, this pull request does not require admin privileges to work). Instead, the source is rather generic. So while this isn't ideal, I think it's useful for the specific case when its needed, which is figuring out why Bugsnag isn't working.  

A look at how this is useful below.  

---

Screenshot of event log limitations: http://i.imgur.com/PjbWHpF.jpg  

EventLog message, with automatic prepended and postpended statement. The actual content sent to the EventLog starts after "The following information was included with the event:" and ends with the stack trace (ends with the stack trace in this example). 

```
The description for Event ID 0 from source Application cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer.

If the event originated on another computer, the display information had to be saved with the event.

The following information was included with the event: 

Bugsnag failed to send error report with exception: System.Net.WebException: The underlying connection was closed: Could not establish trust relationship for the SSL/TLS secure channel. ---> System.Security.Authentication.AuthenticationException: The remote certificate is invalid according to the validation procedure.
   at System.Net.Security.SslState.StartSendAuthResetSignal(ProtocolToken message, AsyncProtocolRequest asyncRequest, Exception exception)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessReceivedBlob(Byte[] buffer, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.StartReceiveBlob(Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ForceAuthentication(Boolean receiveFirst, Byte[] buffer, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslState.ProcessAuthentication(LazyAsyncResult lazyResult)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Net.TlsStream.ProcessAuthentication(LazyAsyncResult result)
   at System.Net.TlsStream.Write(Byte[] buffer, Int32 offset, Int32 size)
   at System.Net.ConnectStream.WriteHeaders(Boolean async)
   --- End of inner exception stack trace ---
   at System.Net.HttpWebRequest.GetResponse()
   at Bugsnag.Notifier.SendJson(String json)

the message resource is present but the message is not found in the string/message table
```
