### PR TITLE
Remove injurious references from MonoRelease

### DIFF
--- a/src/Bugsnag/Bugsnag.Net35.csproj
+++ b/src/Bugsnag/Bugsnag.Net35.csproj
@@ -89,11 +89,11 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <Reference Include="PresentationCore" Condition="'$(Configuration)' != 'MonoRelease'" />
+    <Reference Include="PresentationFramework" Condition="'$(Configuration)' != 'MonoRelease'" />
     <Reference Include="System" />
     <Reference Include="System.configuration" />
-    <Reference Include="System.Deployment" />
+    <Reference Include="System.Deployment" Condition="'$(Configuration)' != 'MonoRelease'" />
     <Reference Include="System.Management" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />

--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <Reference Include="PresentationCore" Condition="'$(Configuration)' != 'MonoRelease'" />
+    <Reference Include="PresentationFramework"  Condition="'$(Configuration)' != 'MonoRelease'" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Deployment" Condition="'$(Configuration)' != 'MonoRelease'" />

--- a/src/Bugsnag/Clients/WPFClient.cs
+++ b/src/Bugsnag/Clients/WPFClient.cs
@@ -18,6 +18,7 @@ namespace Bugsnag.Clients
         {
             Client = new BaseClient(ConfigurationStorage.ConfigSection.Settings);
             Config = Client.Config;
+#if !MONO
             Client.Config.BeforeNotify(error =>
             {
                 var currWindow = Application.Current.Windows.OfType<Window>().SingleOrDefault(x => x.IsActive);
@@ -26,6 +27,7 @@ namespace Bugsnag.Clients
                     error.Context = currWindow.Title;
                 }
             });
+#endif
         }
 
         public static void Start()


### PR DESCRIPTION
I found below issue of `BugsnagMono`. `BugsnagMono` cannot execute on MacOSX.

*https://github.com/bugsnag/bugsnag-dotnet/issues/65 BugsnagMono always raise exception on MacOSX because it tries to load WPF assemblies.*

I changed reference settings of each projects for `MonoRelease` configuration.
As a result, I succeed in booting my `Xamarin.Mac` application on `MacOSX` with  `BugsnagMono.dll`.

I would appreciate it if you could check above issue, and this changes.
