### PR TITLE
improve AggregateException handling

### DIFF
--- a/src/Bugsnag/Payload/Exception.cs
+++ b/src/Bugsnag/Payload/Exception.cs
@@ -34,27 +34,39 @@ namespace Bugsnag.Payload
 
     private static IEnumerable<System.Exception> FlattenAndReverseExceptionTree(System.Exception ex)
     {
-      // ReflectionTypeLoadException is special because the details are in
-      // the LoaderExceptions property
-      if (ex is ReflectionTypeLoadException typeLoadException)
-      {
-        var typeLoadExceptions = new List<System.Exception>();
-        foreach (var loadException in typeLoadException.LoaderExceptions)
-        {
-          typeLoadExceptions.AddRange(FlattenAndReverseExceptionTree(loadException));
-        }
+      if (ex == null) yield break;
 
-        typeLoadExceptions.Add(ex);
-        return typeLoadExceptions;
+      switch (ex)
+      {
+        case ReflectionTypeLoadException typeLoadException:
+          foreach (var exception in typeLoadException.LoaderExceptions)
+          {
+            foreach (var item in FlattenAndReverseExceptionTree(exception))
+            {
+              yield return item;
+            }
+          }
+          break;
+#if !NET35
+        case System.AggregateException aggregateException:
+          foreach (var exception in aggregateException.InnerExceptions)
+          {
+            foreach (var item in FlattenAndReverseExceptionTree(exception))
+            {
+              yield return item;
+            }
+          }
+          break;
+#endif
+        default:
+          foreach (var item in FlattenAndReverseExceptionTree(ex.InnerException))
+          {
+            yield return item;
+          }
+          break;
       }
 
-      var list = new List<System.Exception>();
-      while (ex != null)
-      {
-        list.Add(ex);
-        ex = ex.InnerException;
-      }
-      return list;
+      yield return ex;
     }
   }
 


### PR DESCRIPTION
Unwrap `AggregateException` so that all of the inner exceptions are reported correctly