### PR TITLE
Ignore Class behaviour changes

### DIFF
--- a/src/Bugsnag.AspNet.Core/Middleware.cs
+++ b/src/Bugsnag.AspNet.Core/Middleware.cs
@@ -25,10 +25,7 @@ namespace Bugsnag.AspNet.Core
       }
 
       client.BeforeNotify(report => {
-        foreach (var @event in report.Events)
-        {
-          @event.Request = context.ToRequest();
-        }
+        report.Event.Request = context.ToRequest();
       });
 
       context.Items[HttpContextItemsKey] = client;

--- a/src/Bugsnag.AspNet.WebApi/DelegatingHandler.cs
+++ b/src/Bugsnag.AspNet.WebApi/DelegatingHandler.cs
@@ -57,10 +57,7 @@ namespace Bugsnag.AspNet.WebApi
       }
 
       client.BeforeNotify(report => {
-        foreach (var @event in report.Events)
-        {
-          @event.Request = request.ToRequest();
-        }
+        report.Event.Request = request.ToRequest();
       });
 
       if (client.Configuration.AutoCaptureSessions)

--- a/src/Bugsnag.AspNet/HttpModule.cs
+++ b/src/Bugsnag.AspNet/HttpModule.cs
@@ -22,10 +22,7 @@ namespace Bugsnag.AspNet
       var client = Client.Current;
 
       client.BeforeNotify(report => {
-        foreach (var @event in report.Events)
-        {
-          @event.Request = application.Context.ToRequest();
-        }
+        report.Event.Request = application.Context.ToRequest();
       });
 
       if (client.Configuration.AutoCaptureSessions)

--- a/src/Bugsnag.ConfigurationSection/Configuration.cs
+++ b/src/Bugsnag.ConfigurationSection/Configuration.cs
@@ -223,16 +223,21 @@ namespace Bugsnag.ConfigurationSection
       }
     }
 
-    public string[] IgnoreClasses
+    private Type[] _ignoreClasses;
+
+    public Type[] IgnoreClasses
     {
       get
       {
-        if (InternalIgnoreClasses != null)
+        if (_ignoreClasses == null && InternalIgnoreClasses != null)
         {
-          return InternalIgnoreClasses.Split(',');
+          _ignoreClasses = InternalIgnoreClasses
+            .Split(',')
+            .Select(c => Type.GetType(c))
+            .Where(t => t != null).ToArray();
         }
 
-        return null;
+        return _ignoreClasses;
       }
     }
 

--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -20,6 +20,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/src/Bugsnag/Client.cs
+++ b/src/Bugsnag/Client.cs
@@ -28,7 +28,7 @@ namespace Bugsnag
     /// </summary>
     protected static Middleware[] DefaultInternalMiddleware = new Middleware[] {
       Bugsnag.InternalMiddleware.ReleaseStageFilter,
-      Bugsnag.InternalMiddleware.RemoveIgnoredExceptions,
+      Bugsnag.InternalMiddleware.CheckIgnoreClasses,
       Bugsnag.InternalMiddleware.RemoveProjectRoots,
       Bugsnag.InternalMiddleware.DetectInProjectNamespaces,
       Bugsnag.InternalMiddleware.AttachGlobalMetadata,

--- a/src/Bugsnag/Configuration.cs
+++ b/src/Bugsnag/Configuration.cs
@@ -48,7 +48,7 @@ namespace Bugsnag
 
     public string[] ProjectNamespaces { get; set; }
 
-    public string[] IgnoreClasses { get; set; }
+    public Type[] IgnoreClasses { get; set; }
 
     public KeyValuePair<string, object>[] GlobalMetadata { get; set; }
 

--- a/src/Bugsnag/IConfiguration.cs
+++ b/src/Bugsnag/IConfiguration.cs
@@ -59,7 +59,7 @@ namespace Bugsnag
     /// These will be used to filter exceptions from being sent to Bugsnag based on the Error Class of the exception.
     /// eg. "System.FileNotFoundException"
     /// </summary>
-    string[] IgnoreClasses { get; }
+    Type[] IgnoreClasses { get; }
 
     /// <summary>
     /// This can be used to include these values as metadata in all error reports submitted to Bugsnag.

--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -129,8 +129,6 @@ namespace Bugsnag
     {
       if (report.Configuration.MetadataFilters != null)
       {
-        // should this be applied to the whole report? We should probably focus it to specific sections
-        // of the payload
         foreach (var @event in report.Events)
         {
           @event.App.FilterPayload(report.Configuration.MetadataFilters);

--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -94,9 +94,10 @@ namespace Bugsnag
     };
 
     /// <summary>
-    /// Strips exceptions from the report if they include any 'ignored classes'
+    /// Ignore the report if any of the exceptions in it are included in the
+    /// IgnoreClasses.
     /// </summary>
-    public static Middleware RemoveIgnoredExceptions = report =>
+    public static Middleware CheckIgnoreClasses = report =>
     {
       if (report.Configuration.IgnoreClasses != null && report.Configuration.IgnoreClasses.Any())
       {

--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -99,7 +99,7 @@ namespace Bugsnag
     /// </summary>
     public static Middleware CheckIgnoreClasses = report =>
     {
-      if (report.Configuration.IgnoreClasses != null && report.Configuration.IgnoreClasses.Any())
+      if (!report.Ignored && report.Configuration.IgnoreClasses != null && report.Configuration.IgnoreClasses.Any())
       {
         foreach (var @event in report.Events)
         {

--- a/src/Bugsnag/Payload/Exception.cs
+++ b/src/Bugsnag/Payload/Exception.cs
@@ -75,8 +75,11 @@ namespace Bugsnag.Payload
   /// </summary>
   public class Exception : Dictionary<string, object>
   {
+    private readonly System.Exception _originalException;
+
     public Exception(System.Exception exception)
     {
+      _originalException = exception;
       this.AddToPayload("errorClass", TypeNameHelper.GetTypeDisplayName(exception.GetType()));
       this.AddToPayload("message", exception.Message);
       this.AddToPayload("stacktrace", new StackTrace(exception).ToArray());
@@ -85,5 +88,7 @@ namespace Bugsnag.Payload
     public IEnumerable<StackTraceLine> StackTrace { get { return this.Get("stacktrace") as IEnumerable<StackTraceLine>; } }
 
     public string ErrorClass { get { return this.Get("errorClass") as string; } }
+
+    public System.Exception OriginalException => _originalException;
   }
 }

--- a/src/Bugsnag/Payload/Report.cs
+++ b/src/Bugsnag/Payload/Report.cs
@@ -70,7 +70,7 @@ namespace Bugsnag.Payload
     /// The list of Bugsnag payload events contained in this report. There is usually only a single
     /// event per payload but the Bugsnag error reporting API supports/requires this key to be an array.
     /// </summary>
-    public IEnumerable<Event> Events { get { return this.Get("events") as IEnumerable<Event>; } }
+    public Event[] Events { get { return this.Get("events") as Event[]; } set { this.AddToPayload("events", value); } }
 
     public System.Exception OriginalException => _originalException;
 

--- a/src/Bugsnag/Payload/Session.cs
+++ b/src/Bugsnag/Payload/Session.cs
@@ -29,16 +29,13 @@ namespace Bugsnag.Payload
     {
       if (this.Get("events") is SessionEvents sessions)
       {
-        foreach (var @event in report.Events)
+        if (report.Event.IsHandled)
         {
-          if (@event.IsHandled)
-          {
-            sessions.IncrementHandledCount();
-          }
-          else
-          {
-            sessions.IncrementUnhandledCount();
-          }
+          sessions.IncrementHandledCount();
+        }
+        else
+        {
+          sessions.IncrementUnhandledCount();
         }
       }
     }

--- a/tests/Bugsnag.AspNet.Tests/ClientTests.cs
+++ b/tests/Bugsnag.AspNet.Tests/ClientTests.cs
@@ -33,10 +33,7 @@ namespace Bugsnag.AspNet.Tests
       {
         var context = new BugsnagHttpContext();
         client.Notify(e, report => {
-          foreach (var @event in report.Events)
-          {
-            @event.Request = context.ToRequest();
-          }
+          report.Event.Request = context.ToRequest();
         });
       }
 

--- a/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
+++ b/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\..\src\Bugsnag.ConfigurationSection\Bugsnag.ConfigurationSection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="Complete.config">
+    <None Include="Complete.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tests/Bugsnag.ConfigurationSection.Tests/Complete.config
+++ b/tests/Bugsnag.ConfigurationSection.Tests/Complete.config
@@ -13,7 +13,7 @@
     releaseStage="test"
     projectRoots="C:\app,D:\src"
     projectNamespaces="App.Code,Bugsnag.Tests"
-    ignoreClasses="NotAGoodClass,NotThatBadException"
+    ignoreClasses="System.NotImplementedException,System.DllNotFoundException,Bugsnag.NoSuchException"
     metadataFilters="password,creditcard"
     autoCaptureSessions="true"
     proxyAddress="https://bugsnag.com:8080"

--- a/tests/Bugsnag.ConfigurationSection.Tests/CompleteTests.cs
+++ b/tests/Bugsnag.ConfigurationSection.Tests/CompleteTests.cs
@@ -70,7 +70,7 @@ namespace Bugsnag.ConfigurationSection.Tests
     [Fact]
     public void IgnoreClassesIsSet()
     {
-      Assert.Equal(new[] { "NotAGoodClass", "NotThatBadException" }, TestConfiguration.IgnoreClasses);
+      Assert.Equal(new[] { typeof(NotImplementedException), typeof(DllNotFoundException) }, TestConfiguration.IgnoreClasses);
     }
 
     [Fact]

--- a/tests/Bugsnag.Tests/ClientTests.cs
+++ b/tests/Bugsnag.Tests/ClientTests.cs
@@ -22,10 +22,7 @@ namespace Bugsnag.Tests
       var client = new Client(new Configuration("123456") { Endpoint = server.Endpoint, MetadataFilters = filters });
 
       client.BeforeNotify(r => {
-        foreach (var @event in r.Events)
-        {
-          @event.Metadata["bugsnag"] = metadata;
-        }
+        r.Event.Metadata["bugsnag"] = metadata;
       });
 
       try

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -38,25 +38,19 @@ namespace Bugsnag.Tests
       var configuration = new Configuration("123456") { ProjectRoots = projectRoots };
       var report = new Report(configuration, new System.Exception(), HandledState.ForHandledException(), new Breadcrumb[0], new Session());
 
-      foreach (var @event in report.Events)
+      foreach (var exception in report.Event.Exceptions)
       {
-        foreach (var exception in @event.Exceptions)
-        {
-          var stacktrace = new StackTraceLine[] { new StackTraceLine(fileName, 1, string.Empty, false, null) };
-          exception["stacktrace"] = stacktrace;
-        }
+        var stacktrace = new StackTraceLine[] { new StackTraceLine(fileName, 1, string.Empty, false, null) };
+        exception["stacktrace"] = stacktrace;
       }
 
       InternalMiddleware.RemoveProjectRoots(report);
 
-      foreach (var @event in report.Events)
+      foreach (var exception in report.Event.Exceptions)
       {
-        foreach (var exception in @event.Exceptions)
+        foreach (var stacktraceline in exception.StackTrace)
         {
-          foreach (var stacktraceline in exception.StackTrace)
-          {
-            Assert.Equal(expectedFileName, stacktraceline.FileName);
-          }
+          Assert.Equal(expectedFileName, stacktraceline.FileName);
         }
       }
     }
@@ -73,17 +67,11 @@ namespace Bugsnag.Tests
     {
       var configuration = new Configuration("123456");
       var report = new Report(configuration, new System.Exception(), HandledState.ForHandledException(), new Breadcrumb[0], new Session());
-      foreach (var @event in report.Events)
-      {
-        @event.Request = new Request { Url = requestUrl };
-      }
+      report.Event.Request = new Request { Url = requestUrl };
 
       InternalMiddleware.DetermineDefaultContext(report);
 
-      foreach (var @event in report.Events)
-      {
-        Assert.Equal(expectedContext, @event.Context);
-      }
+      Assert.Equal(expectedContext, report.Event.Context);
     }
 
     public static IEnumerable<object[]> DetermineDefaultContextTestData()

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -1,4 +1,5 @@
 using Bugsnag.Payload;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -91,6 +92,25 @@ namespace Bugsnag.Tests
       yield return new object[] { "https://app.bugsnag.com/user/new/", "/user/new/" };
       yield return new object[] { "https://app.bugsnag.com/user/new/?query=ignored", "/user/new/" };
       yield return new object[] { null, null };
+    }
+
+    [Theory]
+    [MemberData(nameof(IgnoreClassesTestData))]
+    public void IgnoreClassesTest(System.Exception thrownException, Type ignoreClass, bool ignored)
+    {
+      var configuration = new Configuration("123456") { IgnoreClasses = new[] { ignoreClass } };
+      var report = new Report(configuration, thrownException, HandledState.ForHandledException(), new Breadcrumb[0], new Session());
+
+      InternalMiddleware.RemoveIgnoredExceptions(report);
+
+      Assert.Equal(ignored, report.Ignored);
+    }
+
+    public static IEnumerable<object[]> IgnoreClassesTestData()
+    {
+      yield return new object[] { new System.Exception(), typeof(System.Exception), true };
+      yield return new object[] { new System.DllNotFoundException(), typeof(System.Exception), true };
+      yield return new object[] { new System.Exception(), typeof(System.DllNotFoundException), false };
     }
   }
 }

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -101,7 +101,7 @@ namespace Bugsnag.Tests
       var configuration = new Configuration("123456") { IgnoreClasses = new[] { ignoreClass } };
       var report = new Report(configuration, thrownException, HandledState.ForHandledException(), new Breadcrumb[0], new Session());
 
-      InternalMiddleware.RemoveIgnoredExceptions(report);
+      InternalMiddleware.CheckIgnoreClasses(report);
 
       Assert.Equal(ignored, report.Ignored);
     }

--- a/tests/Bugsnag.Tests/Payload/ReportTests.cs
+++ b/tests/Bugsnag.Tests/Payload/ReportTests.cs
@@ -33,21 +33,15 @@ namespace Bugsnag.Tests.Payload
 
       var report = new Report(configuration, exception, severity, breadcrumbs, session);
 
-      foreach (var @event in report.Events)
-      {
-        @event.Metadata.Add("small metadat", "so small");
-        @event.Metadata.Add("large metadata", new String('a', (1024 * 1024)));
-      }
+      report.Event.Metadata.Add("small metadat", "so small");
+      report.Event.Metadata.Add("large metadata", new String('a', (1024 * 1024)));
 
       var data = report.Serialize();
 
       Assert.NotNull(data);
 
-      foreach (var @event in report.Events)
-      {
-        Assert.Null(@event.Breadcrumbs);
-        Assert.Single(@event.Metadata);
-      }
+      Assert.Null(report.Event.Breadcrumbs);
+      Assert.Single(report.Event.Metadata);
     }
   }
 }


### PR DESCRIPTION
This changes a few things about the way that ignore classes work

- the configuration now takes actual types instead of strings to ignore
- if any of the exceptions in the report are an instance of a specified type then the whole report is ignored
- in the configuration section we try to obtain the types that have been specified as strings in the config file and ignore them if they do not correspond to a type