### PR TITLE
Set context with request path

### DIFF
--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Bugsnag.Payload;
 
@@ -145,7 +146,14 @@ namespace Bugsnag
       {
         if (@event.Request != null)
         {
-          @event.Context = @event.Request.Url;
+          if (Uri.TryCreate(@event.Request.Url, UriKind.Absolute, out Uri uri))
+          {
+            @event.Context = uri.AbsolutePath;
+          }
+          else
+          {
+            @event.Context = @event.Request.Url;
+          }
         }
       }
     };

--- a/tests/Bugsnag.AspNet.Tests/ClientTests.cs
+++ b/tests/Bugsnag.AspNet.Tests/ClientTests.cs
@@ -78,7 +78,7 @@ namespace Bugsnag.AspNet.Tests
     [Fact]
     public void ContextIsSet()
     {
-      Assert.Contains("\"context\":\"https://www.bugsnag.com/\"", _request);
+      Assert.Contains("\"context\":\"/\"", _request);
     }
 
     class BugsnagHttpContext : HttpContextBase

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -65,5 +65,32 @@ namespace Bugsnag.Tests
       yield return new object[] { new string[] { @"C:\app" }, @"C:\app\Class.cs", "Class.cs" };
       yield return new object[] { new string[] { @"C:\app\" }, @"C:\app\Class.cs", "Class.cs" };
     }
+
+    [Theory]
+    [MemberData(nameof(DetermineDefaultContextTestData))]
+    public void DetermineDefaultContextTests(string requestUrl, string expectedContext)
+    {
+      var configuration = new Configuration("123456");
+      var report = new Report(configuration, new System.Exception(), HandledState.ForHandledException(), new Breadcrumb[0], new Session());
+      foreach (var @event in report.Events)
+      {
+        @event.Request = new Request { Url = requestUrl };
+      }
+
+      InternalMiddleware.DetermineDefaultContext(report);
+
+      foreach (var @event in report.Events)
+      {
+        Assert.Equal(expectedContext, @event.Context);
+      }
+    }
+
+    public static IEnumerable<object[]> DetermineDefaultContextTestData()
+    {
+      yield return new object[] { "not-a-valid-url", "not-a-valid-url" };
+      yield return new object[] { "https://app.bugsnag.com/user/new/", "/user/new/" };
+      yield return new object[] { "https://app.bugsnag.com/user/new/?query=ignored", "/user/new/" };
+      yield return new object[] { null, null };
+    }
   }
 }


### PR DESCRIPTION
This changes the context that is set on a report with request information to only use the path of the request. This is in line with [bugsnag-node](https://github.com/bugsnag/bugsnag-node) notifier. This is based on feedback from @jmshal.