### PR TITLE
Use ASP.NET Core release stage environment variable

### DIFF
--- a/src/Bugsnag.AspNet.Core/BugsnagStartupFilter.cs
+++ b/src/Bugsnag.AspNet.Core/BugsnagStartupFilter.cs
@@ -14,6 +14,12 @@ namespace Bugsnag.AspNet.Core
   /// </summary>
   public class BugsnagStartupFilter : IStartupFilter
   {
+    static BugsnagStartupFilter()
+    {
+      // populate the env variable that the client expects with the netcore provided value
+      Environment.SetEnvironmentVariable("BUGSNAG_RELEASE_STAGE", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+    }
+
     public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
     {
       return builder =>

--- a/src/Bugsnag.AspNet.Core/BugsnagStartupFilter.cs
+++ b/src/Bugsnag.AspNet.Core/BugsnagStartupFilter.cs
@@ -16,8 +16,13 @@ namespace Bugsnag.AspNet.Core
   {
     static BugsnagStartupFilter()
     {
-      // populate the env variable that the client expects with the netcore provided value
-      Environment.SetEnvironmentVariable("BUGSNAG_RELEASE_STAGE", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+      // populate the env variable that the client expects with the netcore
+      // provided value unless it has already been specified
+      if (Environment.GetEnvironmentVariable("BUGSNAG_RELEASE_STAGE") == null)
+      {
+        Environment.SetEnvironmentVariable("BUGSNAG_RELEASE_STAGE",
+          Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+      }
     }
 
     public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)

--- a/src/Bugsnag/Configuration.cs
+++ b/src/Bugsnag/Configuration.cs
@@ -28,6 +28,7 @@ namespace Bugsnag
       SessionTrackingInterval = TimeSpan.FromSeconds(60);
       MetadataFilters = new[] { "password", "Authorization" };
       MaximumBreadcrumbs = 25;
+      ReleaseStage = Environment.GetEnvironmentVariable("BUGSNAG_RELEASE_STAGE");
     }
 
     public string ApiKey { get; set; }


### PR DESCRIPTION
The configuration in the base client library now defaults the release stage to the `BUGSNAG_RELEASE_STAGE` environment variable. 

The ASP.NET core library will push the `ASPNETCORE_ENVIRONMENT` environment variable into `BUGSNAG_RELEASE_STAGE` if it has not already been set.

This is based on feedback from @jmshal.