### PR TITLE
Only remove a project root once per filename

### DIFF
--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -58,6 +58,7 @@ namespace Bugsnag
                 if (stackTraceLine.FileName.StartsWith(filePrefix, System.StringComparison.Ordinal))
                 {
                   stackTraceLine.FileName = stackTraceLine.FileName.Remove(0, filePrefix.Length);
+                  break;
                 }
               }
             }

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -59,6 +59,10 @@ namespace Bugsnag.Tests
     {
       yield return new object[] { new string[] { @"C:\app" }, @"C:\app\Class.cs", "Class.cs" };
       yield return new object[] { new string[] { @"C:\app\" }, @"C:\app\Class.cs", "Class.cs" };
+      // for this scenario we should only strip the file path once, here we
+      // have a setup where the first prefix will then also cause the second
+      // prefix to match. This should only strip the first prefix
+      yield return new object[] { new string[] { @"C:\app\", @"test\path" }, @"C:\app\test\path\Class.cs", @"test\path\Class.cs" };
     }
 
     [Theory]


### PR DESCRIPTION
This handles the case where a file may have it's root removed which causes it to match the next prefix and be stripped again.