### PR TITLE
Exception ordering

### DIFF
--- a/src/Bugsnag/Payload/Exception.cs
+++ b/src/Bugsnag/Payload/Exception.cs
@@ -36,6 +36,8 @@ namespace Bugsnag.Payload
     {
       if (ex == null) yield break;
 
+      yield return ex;
+
       switch (ex)
       {
         case ReflectionTypeLoadException typeLoadException:
@@ -65,8 +67,6 @@ namespace Bugsnag.Payload
           }
           break;
       }
-
-      yield return ex;
     }
   }
 
@@ -88,6 +88,8 @@ namespace Bugsnag.Payload
     public IEnumerable<StackTraceLine> StackTrace { get { return this.Get("stacktrace") as IEnumerable<StackTraceLine>; } }
 
     public string ErrorClass { get { return this.Get("errorClass") as string; } }
+
+    public string ErrorMessage { get { return this.Get("message") as string; } }
 
     public System.Exception OriginalException => _originalException;
   }


### PR DESCRIPTION
As part of #71 the thrown exception was made the last exception in the list when it should be first. This also expands the tests for inner exceptions and aggregate exceptions to include this constraint