### PR TITLE
Improve appveyor integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 image: Visual Studio 2017
-version: 2.0.{build}-alpha
 build_script:
   - ps: .\build.ps1 -Target Appveyor
 after_build:

--- a/build.cake
+++ b/build.cake
@@ -98,8 +98,18 @@ Task("BuildExamples")
 
 Task("SetVersion")
   .Does(() => {
+    var version = AppVeyor.Environment.Build.Version;
+    if (AppVeyor.Environment.Repository.Tag.IsTag)
+    {
+      version = AppVeyor.Environment.Repository.Tag.Name.TrimStart('v');
+    }
+    else
+    {
+      version = $"{version}-dev{AppVeyor.Environment.Repository.Commit.Id.Substring(0, 7)}";
+    }
+    AppVeyor.UpdateBuildVersion(version);
     var path = "/Project/PropertyGroup/Version";
-    XmlPoke(buildProps,  path, AppVeyor.Environment.Build.Version);
+    XmlPoke(buildProps,  path, version);
   });
 
 Task("Default")

--- a/build.cake
+++ b/build.cake
@@ -105,7 +105,7 @@ Task("SetVersion")
     }
     else
     {
-      version = $"{version}-dev{AppVeyor.Environment.Repository.Commit.Id.Substring(0, 7)}";
+      version = $"{version}-dev-{AppVeyor.Environment.Repository.Commit.Id.Substring(0, 7)}";
     }
     AppVeyor.UpdateBuildVersion(version);
     var path = "/Project/PropertyGroup/Version";


### PR DESCRIPTION
When a tag is pushed appveyor will now version the nuget packages based on the tag, else it will produce a `dev` tagged version.

This means we can push a tag to release a new version, which pushes correctly versioned nuget packages and creates a GitHub release with the dlls