### PR TITLE
Allow the thread to be terminated

### DIFF
--- a/src/Bugsnag/ThreadQueueDelivery.cs
+++ b/src/Bugsnag/ThreadQueueDelivery.cs
@@ -60,7 +60,7 @@ namespace Bugsnag
     private ThreadQueueDelivery()
     {
       _queue = new BlockingQueue<IPayload>();
-      _worker = new Thread(new ThreadStart(ProcessQueue));
+      _worker = new Thread(new ThreadStart(ProcessQueue)) { IsBackground = true };
       _worker.Start();
     }
 


### PR DESCRIPTION
This was lost during a merge and causes the thread to not be terminated when the application closes