### PR TITLE
Callback severity changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## Unreleased
+
+### Enhancements
+
+* Allow the severity to be changed in callbacks
+  | [martin308](https://github.com/martin308)
+  | [#84](https://github.com/bugsnag/bugsnag-dotnet/pull/84)
+
 ## 2.0.1 (2018-03-27)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## Unreleased
 
-### Enhancements
+### Bug fixes
 
 * Allow the severity to be changed in callbacks
   | [martin308](https://github.com/martin308)

--- a/src/Bugsnag/Payload/Event.cs
+++ b/src/Bugsnag/Payload/Event.cs
@@ -8,7 +8,7 @@ namespace Bugsnag.Payload
   /// </summary>
   public class Event : Dictionary<string, object>
   {
-    public Event(string payloadVersion, App app, Device device, System.Exception exception, HandledState severity, IEnumerable<Breadcrumb> breadcrumbs, Session session)
+    public Event(string payloadVersion, App app, Device device, System.Exception exception, HandledState handledState, IEnumerable<Breadcrumb> breadcrumbs, Session session)
     {
       this.AddToPayload("payloadVersion", payloadVersion);
       this.AddToPayload("exceptions", new Exceptions(exception, 5).ToArray());
@@ -18,7 +18,7 @@ namespace Bugsnag.Payload
       this.AddToPayload("breadcrumbs", breadcrumbs);
       this.AddToPayload("session", session);
 
-      foreach (var item in severity)
+      foreach (var item in handledState)
       {
         this[item.Key] = item.Value;
       }

--- a/src/Bugsnag/Payload/Event.cs
+++ b/src/Bugsnag/Payload/Event.cs
@@ -8,6 +8,8 @@ namespace Bugsnag.Payload
   /// </summary>
   public class Event : Dictionary<string, object>
   {
+    private HandledState _handledState;
+
     public Event(string payloadVersion, App app, Device device, System.Exception exception, HandledState handledState, IEnumerable<Breadcrumb> breadcrumbs, Session session)
     {
       this.AddToPayload("payloadVersion", payloadVersion);
@@ -17,11 +19,7 @@ namespace Bugsnag.Payload
       this.AddToPayload("metaData", new Metadata());
       this.AddToPayload("breadcrumbs", breadcrumbs);
       this.AddToPayload("session", session);
-
-      foreach (var item in handledState)
-      {
-        this[item.Key] = item.Value;
-      }
+      HandledState = handledState;
     }
 
     public bool IsHandled
@@ -85,6 +83,30 @@ namespace Bugsnag.Payload
     public IEnumerable<Breadcrumb> Breadcrumbs
     {
       get { return this.Get("breadcrumbs") as IEnumerable<Breadcrumb>; }
+    }
+
+    public Severity Severity
+    {
+      set
+      {
+        HandledState = HandledState.ForCallbackSpecifiedSeverity(value, _handledState);
+      }
+      get
+      {
+        return _handledState.Severity;
+      }
+    }
+
+    private HandledState HandledState
+    {
+      set
+      {
+        _handledState = value;
+        foreach (var item in value)
+        {
+          this[item.Key] = item.Value;
+        }
+      }
     }
 
     /// <summary>

--- a/src/Bugsnag/Payload/HandledState.cs
+++ b/src/Bugsnag/Payload/HandledState.cs
@@ -51,8 +51,13 @@ namespace Bugsnag.Payload
       return new HandledState(previousSeverity.Handled, severity, SeverityReason.ForCallbackSpecifiedSeverity());
     }
 
+    private readonly Severity _severity;
+
+    public Severity Severity => _severity;
+
     HandledState(bool handled, Bugsnag.Severity severity, SeverityReason reason)
     {
+      _severity = severity;
       this.AddToPayload("unhandled", !handled);
       this.AddToPayload("severityReason", reason);
 

--- a/tests/Bugsnag.Tests/Payload/EventTests.cs
+++ b/tests/Bugsnag.Tests/Payload/EventTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bugsnag.Payload;
 using Xunit;
@@ -39,6 +41,45 @@ namespace Bugsnag.Tests.Payload
       {
         Assert.Contains(key, @event.Keys);
       }
+    }
+
+    [Theory]
+    [InlineData(Severity.Error)]
+    [InlineData(Severity.Warning)]
+    [InlineData(Severity.Info)]
+    public void SeverityCanBeRetrieved(Severity severity)
+    {
+      var app = new App("version", "releaseStage", "type");
+      var device = new Device("hostname");
+      var exception = new System.DllNotFoundException();
+      var breadcrumbs = Enumerable.Empty<Breadcrumb>();
+      var session = new Session();
+      var handledState = HandledState.ForUserSpecifiedSeverity(severity);
+
+      var @event = new Event("1", app, device, exception, handledState, breadcrumbs, session);
+
+      Assert.Equal(severity, @event.Severity);
+    }
+
+    [Theory]
+    [InlineData(Severity.Error, Severity.Info)]
+    [InlineData(Severity.Warning, Severity.Error)]
+    [InlineData(Severity.Info, Severity.Warning)]
+    public void SeverityCanBeUpdated(Severity originalSeverity, Severity updatedSeverity)
+    {
+      var app = new App("version", "releaseStage", "type");
+      var device = new Device("hostname");
+      var exception = new System.DllNotFoundException();
+      var breadcrumbs = Enumerable.Empty<Breadcrumb>();
+      var session = new Session();
+      var handledState = HandledState.ForUserSpecifiedSeverity(originalSeverity);
+
+      var @event = new Event("1", app, device, exception, handledState, breadcrumbs, session);
+
+      @event.Severity = updatedSeverity;
+
+      Assert.Equal(updatedSeverity, @event.Severity);
+      Assert.Contains("severityReason", @event.Keys);
     }
   }
 }

--- a/tests/Bugsnag.Tests/Payload/HandledStateTests.cs
+++ b/tests/Bugsnag.Tests/Payload/HandledStateTests.cs
@@ -12,6 +12,7 @@ namespace Bugsnag.Tests.Payload
 
       Assert.True((bool)handledState["unhandled"]);
       Assert.Equal("error", handledState["severity"]);
+      Assert.Equal(Severity.Error, handledState.Severity);
     }
 
     [Fact]
@@ -21,25 +22,30 @@ namespace Bugsnag.Tests.Payload
 
       Assert.False((bool)handledState["unhandled"]);
       Assert.Equal("warning", handledState["severity"]);
+      Assert.Equal(Severity.Warning, handledState.Severity);
     }
 
     [Fact]
     public void UserSpecifiedSeverityPayloadIsCorrect()
     {
-      var handledState = HandledState.ForUserSpecifiedSeverity(Severity.Warning);
+      const Severity warning = Severity.Warning;
+      var handledState = HandledState.ForUserSpecifiedSeverity(warning);
 
       Assert.False((bool)handledState["unhandled"]);
       Assert.Equal("warning", handledState["severity"]);
+      Assert.Equal(warning, handledState.Severity);
     }
 
     [Fact]
     public void CallbackSpecifiedSeverityPayloadIsCorrect()
     {
       var originalHandledState = HandledState.ForUnhandledException();
-      var handledState = HandledState.ForCallbackSpecifiedSeverity(Severity.Info, originalHandledState);
+      const Severity info = Severity.Info;
+      var handledState = HandledState.ForCallbackSpecifiedSeverity(info, originalHandledState);
 
       Assert.True((bool)handledState["unhandled"]); // same as the original severity
       Assert.Equal("info", handledState["severity"]);
+      Assert.Equal(info, handledState.Severity);
     }
   }
 }


### PR DESCRIPTION
While documenting the properties available to before notify callbacks I noticed that the `severity` of the event was missing. This adds in the ability to update the severity of the event during before notify callbacks.