### PR TITLE
Update examples

### DIFF
--- a/examples/aspnet35/Bugsnag.Sample.AspNet35.csproj
+++ b/examples/aspnet35/Bugsnag.Sample.AspNet35.csproj
@@ -40,13 +40,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Bugsnag, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.2.0.12-alpha\lib\net35\Bugsnag.dll</HintPath>
+      <HintPath>packages\Bugsnag.2.0.2\lib\net35\Bugsnag.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.AspNet, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.AspNet.2.0.12-alpha\lib\net35\Bugsnag.AspNet.dll</HintPath>
+      <HintPath>packages\Bugsnag.AspNet.2.0.2\lib\net35\Bugsnag.AspNet.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.ConfigurationSection, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.12-alpha\lib\net35\Bugsnag.ConfigurationSection.dll</HintPath>
+      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.2\lib\net35\Bugsnag.ConfigurationSection.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/examples/aspnet35/nuget.config
+++ b/examples/aspnet35/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/aspnet35/packages.config
+++ b/examples/aspnet35/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bugsnag" version="2.0.12-alpha" targetFramework="net35" />
-  <package id="Bugsnag.AspNet" version="2.0.12-alpha" targetFramework="net35" />
-  <package id="Bugsnag.ConfigurationSection" version="2.0.12-alpha" targetFramework="net35" />
+  <package id="Bugsnag" version="2.0.2" targetFramework="net35" />
+  <package id="Bugsnag.AspNet" version="2.0.2" targetFramework="net35" />
+  <package id="Bugsnag.ConfigurationSection" version="2.0.2" targetFramework="net35" />
 </packages>

--- a/examples/aspnet45-mvc-webapi/aspnet45-mvc-webapi.csproj
+++ b/examples/aspnet45-mvc-webapi/aspnet45-mvc-webapi.csproj
@@ -47,19 +47,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Bugsnag, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.2.0.12-alpha\lib\net45\Bugsnag.dll</HintPath>
+      <HintPath>packages\Bugsnag.2.0.2\lib\net45\Bugsnag.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.AspNet, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.AspNet.2.0.12-alpha\lib\net45\Bugsnag.AspNet.dll</HintPath>
+      <HintPath>packages\Bugsnag.AspNet.2.0.2\lib\net45\Bugsnag.AspNet.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.AspNet.Mvc, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.AspNet.Mvc.2.0.12-alpha\lib\net45\Bugsnag.AspNet.Mvc.dll</HintPath>
+      <HintPath>packages\Bugsnag.AspNet.Mvc.2.0.2\lib\net45\Bugsnag.AspNet.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.AspNet.WebApi, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.AspNet.WebApi.2.0.12-alpha\lib\net45\Bugsnag.AspNet.WebApi.dll</HintPath>
+      <HintPath>packages\Bugsnag.AspNet.WebApi.2.0.2\lib\net45\Bugsnag.AspNet.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.ConfigurationSection, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.12-alpha\lib\net45\Bugsnag.ConfigurationSection.dll</HintPath>
+      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.2\lib\net45\Bugsnag.ConfigurationSection.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/examples/aspnet45-mvc-webapi/nuget.config
+++ b/examples/aspnet45-mvc-webapi/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/aspnet45-mvc-webapi/packages.config
+++ b/examples/aspnet45-mvc-webapi/packages.config
@@ -2,11 +2,11 @@
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
-  <package id="Bugsnag" version="2.0.12-alpha" targetFramework="net45" />
-  <package id="Bugsnag.AspNet" version="2.0.12-alpha" targetFramework="net45" />
-  <package id="Bugsnag.AspNet.Mvc" version="2.0.12-alpha" targetFramework="net45" />
-  <package id="Bugsnag.AspNet.WebApi" version="2.0.12-alpha" targetFramework="net45" />
-  <package id="Bugsnag.ConfigurationSection" version="2.0.12-alpha" targetFramework="net45" />
+  <package id="Bugsnag" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag.AspNet" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag.AspNet.Mvc" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag.AspNet.WebApi" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag.ConfigurationSection" version="2.0.2" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.6" targetFramework="net45" />

--- a/examples/aspnetcore11-mvc/aspnetcore11-mvc.csproj
+++ b/examples/aspnetcore11-mvc/aspnetcore11-mvc.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bugsnag.AspNet.Core" Version="2.0.12-alpha" />
+    <PackageReference Include="Bugsnag.AspNet.Core" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.3" />

--- a/examples/aspnetcore11-mvc/nuget.config
+++ b/examples/aspnetcore11-mvc/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/aspnetcore20-mvc/aspnetcore20-mvc.csproj
+++ b/examples/aspnetcore20-mvc/aspnetcore20-mvc.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bugsnag.AspNet.Core" Version="2.0.12-alpha" />
+    <PackageReference Include="Bugsnag.AspNet.Core" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
   </ItemGroup>
 

--- a/examples/aspnetcore20-mvc/nuget.config
+++ b/examples/aspnetcore20-mvc/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/net35-console/net35-console.csproj
+++ b/examples/net35-console/net35-console.csproj
@@ -33,10 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Bugsnag, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.2.0.12-alpha\lib\net35\Bugsnag.dll</HintPath>
+      <HintPath>packages\Bugsnag.2.0.2\lib\net35\Bugsnag.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.ConfigurationSection, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.12-alpha\lib\net35\Bugsnag.ConfigurationSection.dll</HintPath>
+      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.2\lib\net35\Bugsnag.ConfigurationSection.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/examples/net35-console/nuget.config
+++ b/examples/net35-console/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/net35-console/packages.config
+++ b/examples/net35-console/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bugsnag" version="2.0.12-alpha" targetFramework="net35" />
-  <package id="Bugsnag.ConfigurationSection" version="2.0.12-alpha" targetFramework="net35" />
+  <package id="Bugsnag" version="2.0.2" targetFramework="net35" />
+  <package id="Bugsnag.ConfigurationSection" version="2.0.2" targetFramework="net35" />
 </packages>

--- a/examples/net47-console/net47-console.csproj
+++ b/examples/net47-console/net47-console.csproj
@@ -33,10 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Bugsnag, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.2.0.12-alpha\lib\net45\Bugsnag.dll</HintPath>
+      <HintPath>packages\Bugsnag.2.0.2\lib\net45\Bugsnag.dll</HintPath>
     </Reference>
     <Reference Include="Bugsnag.ConfigurationSection, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.12-alpha\lib\net45\Bugsnag.ConfigurationSection.dll</HintPath>
+      <HintPath>packages\Bugsnag.ConfigurationSection.2.0.2\lib\net45\Bugsnag.ConfigurationSection.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/examples/net47-console/nuget.config
+++ b/examples/net47-console/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/net47-console/packages.config
+++ b/examples/net47-console/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bugsnag" version="2.0.12-alpha" targetFramework="net471" />
-  <package id="Bugsnag.ConfigurationSection" version="2.0.12-alpha" targetFramework="net471" />
+  <package id="Bugsnag" version="2.0.2" targetFramework="net471" />
+  <package id="Bugsnag.ConfigurationSection" version="2.0.2" targetFramework="net471" />
 </packages>

--- a/examples/netcore11-console/netcore11-console.csproj
+++ b/examples/netcore11-console/netcore11-console.csproj
@@ -5,6 +5,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Bugsnag" Version="2.0.12-alpha" />
+    <PackageReference Include="Bugsnag" Version="2.0.2" />
   </ItemGroup>
 </Project>

--- a/examples/netcore11-console/nuget.config
+++ b/examples/netcore11-console/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>

--- a/examples/netcore20-console/netcore20-console.csproj
+++ b/examples/netcore20-console/netcore20-console.csproj
@@ -5,6 +5,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Bugsnag" Version="2.0.12-alpha" />
+    <PackageReference Include="Bugsnag" Version="2.0.2" />
   </ItemGroup>
 </Project>

--- a/examples/netcore20-console/nuget.config
+++ b/examples/netcore20-console/nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="LocalSource" value="packages" />
-    </packageSources>
-</configuration>


### PR DESCRIPTION
- The examples still referenced the old alpha release, they have been updated to use the latest release. - Altered the build script to build the solution files for the examples as we aren't using docker to present the example applications anymore.
- Remove `nuget.config` for each example application. This was only needed during development and seems to break nuget on certain platforms