### PR TITLE
Improve metadata filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 ## Unreleased
 
+### Enhancements
+
+* Improve metadata filtering
+  | [martin308](https://github.com/martin308)
+  | [#90](https://github.com/bugsnag/bugsnag-dotnet/pull/90)
+
 ### Bug fixes
 
 * Request context is now available in custom middleware

--- a/src/Bugsnag/Client.cs
+++ b/src/Bugsnag/Client.cs
@@ -162,8 +162,6 @@ namespace Bugsnag
 
       if (!report.Ignored)
       {
-        Bugsnag.InternalMiddleware.ApplyMetadataFilters(report);
-
         _delivery.Send(report);
 
         Breadcrumbs.Leave(Breadcrumb.FromReport(report));

--- a/src/Bugsnag/IFilterable.cs
+++ b/src/Bugsnag/IFilterable.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+
+namespace Bugsnag
+{
+  /// <summary>
+  /// An interface to mark payload objects as having filtering applied to them.
+  /// </summary>
+  public interface IFilterable : IDictionary
+  {
+  }
+}

--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -120,6 +120,12 @@ namespace Bugsnag
       }
     };
 
+    /// <summary>
+    /// Applies the configured metadata filters to specified sections of the report.
+    /// 
+    /// This is no longer used by the notifier and can be removed in the next
+    /// major version bump.
+    /// </summary>
     public static Middleware ApplyMetadataFilters = report =>
     {
       if (report.Configuration.MetadataFilters != null)

--- a/src/Bugsnag/Payload/App.cs
+++ b/src/Bugsnag/Payload/App.cs
@@ -5,7 +5,7 @@ namespace Bugsnag.Payload
   /// <summary>
   /// Represents the "app" key in the error report payload.
   /// </summary>
-  public class App : Dictionary<string, object>
+  public class App : Dictionary<string, object>, IFilterable
   {
     public App(IConfiguration configuration) : this(configuration.AppVersion, configuration.ReleaseStage, configuration.AppType)
     {

--- a/src/Bugsnag/Payload/BatchedSessions.cs
+++ b/src/Bugsnag/Payload/BatchedSessions.cs
@@ -8,6 +8,7 @@ namespace Bugsnag.Payload
   public class BatchedSessions : Dictionary<string, object>, IPayload
   {
     private readonly KeyValuePair<string, string>[] _headers;
+    private readonly IConfiguration _configuration;
 
     public BatchedSessions(IConfiguration configuration, IEnumerable<KeyValuePair<string, long>> sessionData) : this(configuration, NotifierInfo.Instance, new App(configuration), new Device(), sessionData)
     {
@@ -16,6 +17,7 @@ namespace Bugsnag.Payload
 
     public BatchedSessions(IConfiguration configuration, NotifierInfo notifier, App app, Device device, IEnumerable<KeyValuePair<string, long>> sessionData)
     {
+      _configuration = configuration;
       Endpoint = configuration.SessionEndpoint;
       Proxy = configuration.Proxy;
       _headers = new KeyValuePair<string, string>[] {
@@ -36,7 +38,7 @@ namespace Bugsnag.Payload
 
     public byte[] Serialize()
     {
-      return Serializer.SerializeObjectToByteArray(this);
+      return Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
     }
   }
 

--- a/src/Bugsnag/Payload/Device.cs
+++ b/src/Bugsnag/Payload/Device.cs
@@ -7,7 +7,7 @@ namespace Bugsnag.Payload
   /// <summary>
   /// Represents the "device" key in the error report payload.
   /// </summary>
-  public class Device : Dictionary<string, object>
+  public class Device : Dictionary<string, object>, IFilterable
   {
     public Device() : this(Hostname)
     {

--- a/src/Bugsnag/Payload/Metadata.cs
+++ b/src/Bugsnag/Payload/Metadata.cs
@@ -5,7 +5,7 @@ namespace Bugsnag.Payload
   /// <summary>
   /// Represents Metadata that can be attached to error reports sent to Bugsnag.
   /// </summary>
-  public class Metadata : Dictionary<string, object>
+  public class Metadata : Dictionary<string, object>, IFilterable
   {
   }
 }

--- a/src/Bugsnag/Payload/PayloadExtensions.cs
+++ b/src/Bugsnag/Payload/PayloadExtensions.cs
@@ -29,7 +29,7 @@ namespace Bugsnag.Payload
           {
             dictionary[key] = value;
           }
-          else if(dictionary.ContainsKey(key))
+          else if (dictionary.ContainsKey(key))
           {
             dictionary.Remove(key);
           }
@@ -46,11 +46,26 @@ namespace Bugsnag.Payload
       return value;
     }
 
+    /// <summary>
+    /// Filters an IDictionary using the provided filters.
+    ///
+    /// This is no longer used and can be removed in the next major version bump.
+    /// </summary>
+    /// <param name="dictionary"></param>
+    /// <param name="filters"></param>
     public static void FilterPayload(this IDictionary dictionary, string[] filters)
     {
       dictionary.FilterPayload(filters, new Dictionary<object, bool>());
     }
 
+    /// <summary>
+    /// Filters an IDictionary using the provided filters.
+    ///
+    /// This is no longer used and can be removed in the next major version bump.
+    /// </summary>
+    /// <param name="dictionary"></param>
+    /// <param name="filters"></param>
+    /// <param name="seen"></param>
     public static void FilterPayload(this IDictionary dictionary, string[] filters, IDictionary seen)
     {
       if (seen.Contains(dictionary))
@@ -64,7 +79,7 @@ namespace Bugsnag.Payload
       {
         if (key != null && dictionary.Contains(key))
         {
-          dictionary[key] = "[Filtered]"; 
+          dictionary[key] = "[Filtered]";
         }
       }
 
@@ -89,6 +104,14 @@ namespace Bugsnag.Payload
       seen.Remove(dictionary);
     }
 
+    /// <summary>
+    /// Filters an IEnumerable using the provided filters.
+    ///
+    /// This is no longer used and can be removed in the next major version bump.
+    /// </summary>
+    /// <param name="enumerable"></param>
+    /// <param name="filters"></param>
+    /// <param name="seen"></param>
     public static void FilterPayload(this IEnumerable enumerable, string[] filters, IDictionary seen)
     {
       if (seen.Contains(enumerable))
@@ -119,6 +142,13 @@ namespace Bugsnag.Payload
       seen.Remove(enumerable);
     }
 
+    /// <summary>
+    /// Filters a Uri using the provided filters
+    ///
+    /// This is no longer used and can be removed in the next major version bump.
+    /// </summary>
+    /// <param name="uri"></param>
+    /// <param name="filters"></param>
     public static void FilterUri(this Uri uri, string[] filters)
     {
       // need to figure out a good way to modify this, it is basically readonly at this point

--- a/src/Bugsnag/Payload/Report.cs
+++ b/src/Bugsnag/Payload/Report.cs
@@ -97,14 +97,14 @@ namespace Bugsnag.Payload
 
       try
       {
-        data = Serializer.SerializeObjectToByteArray(this);
+        data = Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
 
         if (data.Length > MaximumSize)
         {
           Event.TrimExtraData();
         }
 
-        data = Serializer.SerializeObjectToByteArray(this);
+        data = Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
       }
       catch (System.Exception exception)
       {

--- a/src/Bugsnag/Payload/Request.cs
+++ b/src/Bugsnag/Payload/Request.cs
@@ -5,7 +5,7 @@ namespace Bugsnag.Payload
   /// <summary>
   /// Represents the "request" key in the error report payload.
   /// </summary>
-  public class Request : Dictionary<string, object>
+  public class Request : Dictionary<string, object>, IFilterable
   {
     public string ClientIp { get { return this.Get("clientIp") as string; } set { this.AddToPayload("clientIp", value); } }
 

--- a/src/Bugsnag/Payload/User.cs
+++ b/src/Bugsnag/Payload/User.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Bugsnag.Payload
 {
-  public class User : Dictionary<string, string>
+  public class User : Dictionary<string, string>, IFilterable
   {
     public string Id
     {

--- a/src/Bugsnag/Serializer.cs
+++ b/src/Bugsnag/Serializer.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 
 namespace Bugsnag
@@ -7,9 +9,18 @@ namespace Bugsnag
   {
     public static string SerializeObject(object obj)
     {
+      return SerializeObject(obj, new string[0]);
+    }
+
+    public static string SerializeObject(object obj, string[] filters)
+    {
+      var parsedFilters = filters != null ?
+        filters.ToDictionary(m => m, m => true) :
+        new Dictionary<string, bool>();
+
       try
       {
-        return SimpleJson.SimpleJson.SerializeObject(obj);
+        return SimpleJson.SimpleJson.SerializeObject(obj, parsedFilters);
       }
       catch (System.Exception exception)
       {
@@ -21,9 +32,14 @@ namespace Bugsnag
 
     public static byte[] SerializeObjectToByteArray(object obj)
     {
+      return SerializeObjectToByteArray(obj, new string[0]);
+    }
+
+    public static byte[] SerializeObjectToByteArray(object obj, string[] filters)
+    {
       try
       {
-        var serializedObject = SerializeObject(obj);
+        var serializedObject = SerializeObject(obj, filters);
         return Encoding.UTF8.GetBytes(serializedObject);
       }
       catch (System.Exception exception)

--- a/tests/Bugsnag.Tests/PayloadExtensionsTests.cs
+++ b/tests/Bugsnag.Tests/PayloadExtensionsTests.cs
@@ -1,0 +1,55 @@
+using Bugsnag.Payload;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Bugsnag.Tests
+{
+  public class PayloadExtensionsTests
+  {
+    [Theory]
+    [MemberData(nameof(PayloadTestData))]
+    public void AddToPayloadTests(Dictionary<string, object> dictionary, string key, object value, object expectedValue)
+    {
+      dictionary.AddToPayload(key, value);
+
+      if (expectedValue == null)
+      {
+        Assert.DoesNotContain(key, dictionary.Keys);
+      }
+      else
+      {
+        Assert.Equal(expectedValue, dictionary[key]);
+      }
+    }
+
+    public static IEnumerable<object[]> PayloadTestData()
+    {
+      yield return new object[] { new Dictionary<string, object>(), "key", 1, 1 };
+      yield return new object[] { new Dictionary<string, object>(), "key", null, null };
+      yield return new object[] { new Dictionary<string, object>(), "key", "", null };
+      yield return new object[] { new Dictionary<string, object>(), "key", "value", "value" };
+      yield return new object[] { new Dictionary<string, object> { { "key", 1 } }, "key", null, null };
+      yield return new object[] { new Dictionary<string, object> { { "key", 1 } }, "key", "", null };
+    }
+
+    [Fact]
+    public void GetExistingKey()
+    {
+      var dictionary = new Dictionary<string, object> { { "key", "value" } };
+
+      Assert.Equal("value", dictionary.Get("key"));
+    }
+
+    [Fact]
+    public void GetNonExistentKeyReturnsNull()
+    {
+      var dictionary = new Dictionary<string, object>();
+
+      Assert.Null(dictionary.Get("key"));
+    }
+  }
+}


### PR DESCRIPTION
- Applies the metadata filtering to all of the required sections of the payload. Previously we were missing both `request` and `user`
- Refactor how filtering is applied
- Apply the metadata filtering to the sessions payload as well