### PR TITLE
Improve request context setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 ### Bug fixes
 
+* Request context is now available in custom middleware
+  | [martin308](https://github.com/martin308)
+  | [#91](https://github.com/bugsnag/bugsnag-dotnet/pull/91)
+
 * Only set the context to the current request URL if the context has not already been set
   | [tremlab](https://github.com/tremlab)
   | [#89](https://github.com/bugsnag/bugsnag-dotnet/pull/89)

--- a/src/Bugsnag/Client.cs
+++ b/src/Bugsnag/Client.cs
@@ -162,7 +162,6 @@ namespace Bugsnag
 
       if (!report.Ignored)
       {
-        Bugsnag.InternalMiddleware.DetermineDefaultContext(report);
         Bugsnag.InternalMiddleware.ApplyMetadataFilters(report);
 
         _delivery.Send(report);

--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -129,20 +129,5 @@ namespace Bugsnag
         report.Event.Metadata.FilterPayload(report.Configuration.MetadataFilters);
       }
     };
-
-    public static Middleware DetermineDefaultContext = report =>
-    {
-      if (report.Event.Request != null && report.Event.Context == null)
-      {
-        if (Uri.TryCreate(report.Event.Request.Url, UriKind.Absolute, out Uri uri))
-        {
-          report.Event.Context = uri.AbsolutePath;
-        }
-        else
-        {
-          report.Event.Context = report.Event.Request.Url;
-        }
-      }
-    };
   }
 }

--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -129,5 +129,26 @@ namespace Bugsnag
         report.Event.Metadata.FilterPayload(report.Configuration.MetadataFilters);
       }
     };
+
+    /// <summary>
+    /// Uses a request if set on the report to provide a default context.
+    /// 
+    /// This is no longer used by the notifier and can be removed in the next
+    /// major version bump. Replaced by code in <see cref="Event.Request"/>
+    /// </summary>
+    public static Middleware DetermineDefaultContext = report =>
+    {
+      if (report.Event.Request != null && report.Event.Context == null)
+      {
+        if (Uri.TryCreate(report.Event.Request.Url, UriKind.Absolute, out Uri uri))
+        {
+          report.Event.Context = uri.AbsolutePath;
+        }
+        else
+        {
+          report.Event.Context = report.Event.Request.Url;
+        }
+      }
+    };
   }
 }

--- a/src/Bugsnag/Payload/Event.cs
+++ b/src/Bugsnag/Payload/Event.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -77,7 +78,22 @@ namespace Bugsnag.Payload
     public Request Request
     {
       get { return this.Get("request") as Request; }
-      set { this.AddToPayload("request", value); }
+      set
+      {
+        if (Context == null && value != null)
+        {
+          if (Uri.TryCreate(value.Url, UriKind.Absolute, out Uri uri))
+          {
+            Context = uri.AbsolutePath;
+          }
+          else
+          {
+            Context = value.Url;
+          }
+        }
+
+        this.AddToPayload("request", value);
+      }
     }
 
     public IEnumerable<Breadcrumb> Breadcrumbs

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -66,32 +66,6 @@ namespace Bugsnag.Tests
     }
 
     [Theory]
-    [MemberData(nameof(DetermineDefaultContextTestData))]
-    public void DetermineDefaultContextTests(string requestUrl, string existingContext, string expectedContext)
-    {
-      var configuration = new Configuration("123456");
-      var report = new Report(configuration, new System.Exception(), HandledState.ForHandledException(), new Breadcrumb[0], new Session());
-      report.Event.Request = new Request { Url = requestUrl };
-      report.Event.Context = existingContext;
-
-      InternalMiddleware.DetermineDefaultContext(report);
-
-      Assert.Equal(expectedContext, report.Event.Context);
-    }
-
-    public static IEnumerable<object[]> DetermineDefaultContextTestData()
-    {
-      yield return new object[] { "not-a-valid-url", null, "not-a-valid-url" };
-      yield return new object[] { "https://app.bugsnag.com/user/new/", null, "/user/new/" };
-      yield return new object[] { "https://app.bugsnag.com/user/new/?query=ignored", null, "/user/new/" };
-      yield return new object[] { null, null, null };
-      yield return new object[] { "not-a-valid-url", "existing-context", "existing-context" };
-      yield return new object[] { "https://app.bugsnag.com/user/new/", "existing-context", "existing-context" };
-      yield return new object[] { "https://app.bugsnag.com/user/new/?query=ignored", "existing-context", "existing-context" };
-      yield return new object[] { null, "existing-context", "existing-context" };
-    }
-
-    [Theory]
     [MemberData(nameof(IgnoreClassesTestData))]
     public void IgnoreClassesTest(System.Exception thrownException, Type ignoreClass, bool ignored)
     {

--- a/tests/Bugsnag.Tests/Payload/EventTests.cs
+++ b/tests/Bugsnag.Tests/Payload/EventTests.cs
@@ -81,5 +81,29 @@ namespace Bugsnag.Tests.Payload
       Assert.Equal(updatedSeverity, @event.Severity);
       Assert.Contains("severityReason", @event.Keys);
     }
+
+    [Theory]
+    [MemberData(nameof(ContextIsSetByRequestData))]
+    public void ContextIsSetByRequest(Request request, string existingContext, string expectedContext)
+    {
+      var configuration = new Configuration("123456");
+      var report = new Report(configuration, new System.Exception(), HandledState.ForHandledException(), new Breadcrumb[0], new Session());
+      report.Event.Context = existingContext;
+      report.Event.Request = request;
+
+      Assert.Equal(expectedContext, report.Event.Context);
+    }
+
+    public static IEnumerable<object[]> ContextIsSetByRequestData()
+    {
+      yield return new object[] { new Request { Url = "not-a-valid-url" }, null, "not-a-valid-url" };
+      yield return new object[] { new Request { Url = "https://app.bugsnag.com/user/new/" }, null, "/user/new/" };
+      yield return new object[] { new Request { Url = "https://app.bugsnag.com/user/new/?query=ignored" }, null, "/user/new/" };
+      yield return new object[] { null, null, null };
+      yield return new object[] { new Request { Url = "not-a-valid-url" }, "existing-context", "existing-context" };
+      yield return new object[] { new Request { Url = "https://app.bugsnag.com/user/new/" }, "existing-context", "existing-context" };
+      yield return new object[] { new Request { Url = "https://app.bugsnag.com/user/new/?query=ignored" }, "existing-context", "existing-context" };
+      yield return new object[] { null, "existing-context", "existing-context" };
+    }
   }
 }


### PR DESCRIPTION
This was raised by @tremlab, the context from the request is not available in the middleware due it being set after the middleware has already been run. This fixes this issue by moving the setting of the context out of the middleware and moving it to being set when the request is updated in the event object.