### PR TITLE
Skip sending empty sessions data payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Changelog
 
 ### Bug fixes
 
+* Only send session data when it exists
+  | [martin308](https://github.com/martin308)
+  | [98](https://github.com/bugsnag/bugsnag-dotnet/pull/98)
+
 * Request context is now available in custom middleware
   | [martin308](https://github.com/martin308)
   | [#91](https://github.com/bugsnag/bugsnag-dotnet/pull/91)

--- a/src/Bugsnag/SessionsStore.cs
+++ b/src/Bugsnag/SessionsStore.cs
@@ -2,6 +2,7 @@ using Bugsnag.Payload;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Linq;
 
 namespace Bugsnag
 {
@@ -27,7 +28,8 @@ namespace Bugsnag
 
       lock (_lock)
       {
-        foreach (var item in _store)
+        // we only care about entries that have session data
+        foreach (var item in _store.Where(d => d.Value.Any()))
         {
           sessionData[item.Key] = new Dictionary<string, long>(item.Value);
           _store[item.Key].Clear();

--- a/tests/Bugsnag.AspNet.Core.Tests/UseExceptionHandlerTests.cs
+++ b/tests/Bugsnag.AspNet.Core.Tests/UseExceptionHandlerTests.cs
@@ -24,7 +24,7 @@ namespace Bugsnag.AspNet.Core.Tests
 
     public async Task InitializeAsync()
     {
-      var bugsnag = new Bugsnag.Tests.TestServer(1);
+      var bugsnag = new Bugsnag.Tests.TestServer();
       bugsnag.Start();
 
       var builder = new WebHostBuilder()
@@ -47,7 +47,7 @@ namespace Bugsnag.AspNet.Core.Tests
       var client = server.CreateClient();
       var response = await client.SendAsync(new System.Net.Http.HttpRequestMessage() { RequestUri = new Uri("/error", UriKind.Relative) });
 
-      var bugsnags = await bugsnag.Requests();
+      var bugsnags = await bugsnag.Requests(1);
 
       BugsnagPayload = bugsnags.First();
     }

--- a/tests/Bugsnag.AspNet.Core.Tests/WebHostTests.cs
+++ b/tests/Bugsnag.AspNet.Core.Tests/WebHostTests.cs
@@ -30,7 +30,7 @@ namespace Bugsnag.AspNet.Core.Tests
     [Fact]
     public async void TestWithDeveloperExceptionPage()
     {
-      var bugsnag = new Bugsnag.Tests.TestServer(1);
+      var bugsnag = new Bugsnag.Tests.TestServer();
       bugsnag.Start();
 
       var builder = new WebHostBuilder()
@@ -46,7 +46,7 @@ namespace Bugsnag.AspNet.Core.Tests
       var client = server.CreateClient();
       var response = await client.SendAsync(new System.Net.Http.HttpRequestMessage());
 
-      var bugsnags = await bugsnag.Requests();
+      var bugsnags = await bugsnag.Requests(1);
 
       Assert.NotNull(response);
     }

--- a/tests/Bugsnag.AspNet.Tests/ClientTests.cs
+++ b/tests/Bugsnag.AspNet.Tests/ClientTests.cs
@@ -19,7 +19,7 @@ namespace Bugsnag.AspNet.Tests
 
     public async Task InitializeAsync()
     {
-      var server = new TestServer(1);
+      var server = new TestServer();
 
       server.Start();
 
@@ -37,7 +37,7 @@ namespace Bugsnag.AspNet.Tests
         });
       }
 
-      var requests = await server.Requests();
+      var requests = await server.Requests(1);
 
       _request = requests.Single();
     }

--- a/tests/Bugsnag.AspNet.WebApi.Tests/WebHostTests.cs
+++ b/tests/Bugsnag.AspNet.WebApi.Tests/WebHostTests.cs
@@ -22,7 +22,7 @@ namespace Bugsnag.AspNet.WebApi.Tests
     [Fact]
     public async void Test()
     {
-      var bugsnagServer = new TestServer(1);
+      var bugsnagServer = new TestServer();
 
       bugsnagServer.Start();
 
@@ -37,7 +37,7 @@ namespace Bugsnag.AspNet.WebApi.Tests
 
       var response = await client.SendAsync(request);
 
-      var responses = await bugsnagServer.Requests();
+      var responses = await bugsnagServer.Requests(1);
 
       Assert.Single(responses);
       Assert.Contains("Bugsnag is great!", responses.Single());

--- a/tests/Bugsnag.Tests/ClientTests.cs
+++ b/tests/Bugsnag.Tests/ClientTests.cs
@@ -12,7 +12,7 @@ namespace Bugsnag.Tests
     [Fact]
     public async void TestThrownException()
     {
-      var server = new TestServer(1);
+      var server = new TestServer();
 
       server.Start();
 
@@ -36,7 +36,7 @@ namespace Bugsnag.Tests
         client.Notify(e);
       }
 
-      var requests = await server.Requests();
+      var requests = await server.Requests(1);
 
       Assert.Single(requests);
     }
@@ -52,7 +52,7 @@ namespace Bugsnag.Tests
 
       public async Task InitializeAsync()
       {
-        var server = new TestServer(1);
+        var server = new TestServer();
 
         server.Start();
 
@@ -69,7 +69,7 @@ namespace Bugsnag.Tests
 
         TestNotifyMethod(client);
 
-        var requests = await server.Requests();
+        var requests = await server.Requests(1);
 
         BugsnagPayload = requests.Single();
       }

--- a/tests/Bugsnag.Tests/SessionTrackingTests.cs
+++ b/tests/Bugsnag.Tests/SessionTrackingTests.cs
@@ -16,7 +16,7 @@ namespace Bugsnag.Tests
     [Fact]
     public async void CurrentSessionCanBeSet()
     {
-      var server = new TestServer(1);
+      var server = new TestServer();
 
       server.Start();
 
@@ -24,7 +24,7 @@ namespace Bugsnag.Tests
 
       sessionTracking.CreateSession();
 
-      var requests = await server.Requests();
+      var requests = await server.Requests(1);
 
       Assert.NotNull(sessionTracking.CurrentSession);
     }

--- a/tests/Bugsnag.Tests/SessionTrackingTests.cs
+++ b/tests/Bugsnag.Tests/SessionTrackingTests.cs
@@ -33,7 +33,7 @@ namespace Bugsnag.Tests
     }
 
     [Fact]
-    public async void CurrentSessionCanBeSetO()
+    public async void EmptySessionsPayloadsAreNotSent()
     {
       var server = new TestServer();
 

--- a/tests/Bugsnag.Tests/ThreadQueueDeliveryTests.cs
+++ b/tests/Bugsnag.Tests/ThreadQueueDeliveryTests.cs
@@ -13,7 +13,7 @@ namespace Bugsnag.Tests
     {
       var numberOfRequests = 500;
 
-      var server = new TestServer(numberOfRequests);
+      var server = new TestServer();
 
       server.Start();
 
@@ -23,7 +23,7 @@ namespace Bugsnag.Tests
         ThreadQueueDelivery.Instance.Send(payload);
       }
 
-      var requests = await server.Requests();
+      var requests = await server.Requests(numberOfRequests);
 
       Assert.Equal(numberOfRequests, requests.Count());
     }

--- a/tests/Bugsnag.Tests/WebRequestTests.cs
+++ b/tests/Bugsnag.Tests/WebRequestTests.cs
@@ -12,7 +12,7 @@ namespace Bugsnag.Tests
     public async void Test()
     {
       var numerOfRequests = 1;
-      var server = new TestServer(numerOfRequests);
+      var server = new TestServer();
       server.Start();
 
       var webRequest = new WebRequest();
@@ -23,7 +23,7 @@ namespace Bugsnag.Tests
       var response = await Task.Factory.FromAsync((callback, state) => webRequest.BeginSend(server.Endpoint, null, headers, rawPayload, callback, state), webRequest.EndSend, null);
       Assert.Equal(HttpStatusCode.OK, response.HttpStatusCode);
 
-      var requests = await server.Requests();
+      var requests = await server.Requests(numerOfRequests);
 
       Assert.Equal(numerOfRequests, requests.Count());
     }


### PR DESCRIPTION
## Goal

Currently even if there has been no session data generated we still send a payload to Bugsnag. If no session data has been generated then we should skip sending the payload

## Changeset

### Added

The most substantial change was in the test code. We needed to support providing a timeout to our test server when we are expecting a certain number of requests. This was added so that we could test the scenario above.

### Changed

The functional change made was to check that session data exists before generating the payload to send.

## Tests

A test was added that tests when a single session is created that we only see one request to the sessions server.

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
