### PR TITLE
Serialization optimization

### DIFF
--- a/src/Bugsnag/Payload/Event.cs
+++ b/src/Bugsnag/Payload/Event.cs
@@ -129,17 +129,21 @@ namespace Bugsnag.Payload
     /// Called if the payload size is too large to send, removes data so that the payload
     /// can be sent succesfully.
     /// </summary>
-    public void TrimExtraData()
+    public bool TrimExtraData()
     {
+      var trimmed = false;
       if (Breadcrumbs != null)
       {
         Remove("breadcrumbs");
+        trimmed = true;
       }
       if (Metadata != null)
       {
         Metadata.Clear();
         Metadata.Add("notifier", "The serialized payload exceeded the 1MB size limit. Metadata and breadcrumbs have been stripped to make the payload a deliverable size.");
+        trimmed = true;
       }
+      return trimmed;
     }
   }
 }

--- a/src/Bugsnag/Payload/Report.cs
+++ b/src/Bugsnag/Payload/Report.cs
@@ -102,9 +102,8 @@ namespace Bugsnag.Payload
         if (data.Length > MaximumSize)
         {
           Event.TrimExtraData();
+          data = Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
         }
-
-        data = Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
       }
       catch (System.Exception exception)
       {

--- a/src/Bugsnag/Payload/Report.cs
+++ b/src/Bugsnag/Payload/Report.cs
@@ -99,9 +99,8 @@ namespace Bugsnag.Payload
       {
         data = Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
 
-        if (data.Length > MaximumSize)
+        if (data.Length > MaximumSize && Event.TrimExtraData())
         {
-          Event.TrimExtraData();
           data = Serializer.SerializeObjectToByteArray(this, _configuration.MetadataFilters);
         }
       }


### PR DESCRIPTION
## Goal

Do second serialize call only if there is any data being trimmed

## Tests

Tested by running existing unit tests. No new test added.

## Discussion

### Outstanding Questions

`IPayload.Serialize()` returns byte array and `SimpleJson.SerializeObject()` returns string. 
Both will probably cause allocation in Large Object Heap for anything above ~85 KB.
I'm currently facing `OutOfMemoryException` and this is probably one of the contributor.
Better solution should be to serialize to stream. Don't want to depend on existing NuGet package?

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [X] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
