### PR TITLE
Fix InProject namespaces detection

### DIFF
--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -80,7 +80,11 @@ namespace Bugsnag
           {
             foreach (var @namespace in report.Configuration.ProjectNamespaces)
             {
-              stackTraceLine.InProject = stackTraceLine.MethodName.StartsWith(@namespace);
+              if (stackTraceLine.MethodName.StartsWith(@namespace))
+              {
+                stackTraceLine.InProject = true;
+                break;
+              }
             }
           }
         }


### PR DESCRIPTION
## Goal

Fix the "in project" namespace detection for stack trace lines. (issue #100)

## Changeset

### Changed
Just change the way StackTraceLine.InProject property is updated and break out of the loop on ProjectNamespaces as soon as the line is detected as in project.

## Tests
I've done some manual test by sending exception to my bugsnag project



### Linked issues

Fixes #100 

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
