### PR TITLE
improved http exception handling

### DIFF
--- a/src/Bugsnag/WebRequest.cs
+++ b/src/Bugsnag/WebRequest.cs
@@ -57,7 +57,10 @@ namespace Bugsnag
 
     public IAsyncResult BeginSend(Uri endpoint, IWebProxy proxy, KeyValuePair<string, string>[] headers, byte[] report, AsyncCallback callback, object state)
     {
-      var request = System.Net.WebRequest.Create(endpoint);
+      var request = (HttpWebRequest)System.Net.WebRequest.Create(endpoint);
+#if !NETSTANDARD1_3
+      request.KeepAlive = false;
+#endif
       request.Method = "POST";
       request.ContentType = "application/json";
       if (proxy != null)

--- a/src/Bugsnag/WebRequest.cs
+++ b/src/Bugsnag/WebRequest.cs
@@ -10,15 +10,15 @@ namespace Bugsnag
   {
     private class WebRequestState
     {
-      public AsyncCallback Callback { get; private set; }
+      public AsyncCallback Callback { get; }
 
-      public object OriginalState { get; private set; }
+      public object OriginalState { get; }
 
-      public Uri Endpoint { get; private set; }
+      public Uri Endpoint { get; }
 
-      public byte[] Report { get; private set; }
+      public byte[] Report { get; }
 
-      public System.Net.WebRequest Request { get; private set; }
+      public System.Net.WebRequest Request { get; }
 
       public HttpWebResponse Response { get; set; }
 
@@ -34,23 +34,22 @@ namespace Bugsnag
 
     private class WebRequestAsyncResult : IAsyncResult
     {
-      public bool IsCompleted { get { return _innerAsyncResult.IsCompleted; } }
+      public bool IsCompleted => InnerAsyncResult.IsCompleted;
 
-      public WaitHandle AsyncWaitHandle { get { return _innerAsyncResult.AsyncWaitHandle; } }
+      public WaitHandle AsyncWaitHandle => InnerAsyncResult.AsyncWaitHandle;
 
       public object AsyncState => WebRequestState.OriginalState;
 
-      public bool CompletedSynchronously { get { return _innerAsyncResult.CompletedSynchronously; } }
+      public bool CompletedSynchronously => InnerAsyncResult.CompletedSynchronously;
 
-      public WebRequestState WebRequestState => _webRequestState;
+      public WebRequestState WebRequestState { get; }
 
-      private readonly IAsyncResult _innerAsyncResult;
-      private readonly WebRequestState _webRequestState;
+      private IAsyncResult InnerAsyncResult { get; }
 
       public WebRequestAsyncResult(IAsyncResult innerAsyncResult, WebRequestState webRequestState)
       {
-        _innerAsyncResult = innerAsyncResult;
-        _webRequestState = webRequestState;
+        InnerAsyncResult = innerAsyncResult;
+        WebRequestState = webRequestState;
       }
     }
 
@@ -128,13 +127,11 @@ namespace Bugsnag
 
   public class WebResponse
   {
-    private readonly HttpStatusCode _httpStatusCode;
+    public HttpStatusCode HttpStatusCode { get; }
 
     public WebResponse(HttpStatusCode httpStatusCode)
     {
-      _httpStatusCode = httpStatusCode;
+      HttpStatusCode = httpStatusCode;
     }
-
-    public HttpStatusCode HttpStatusCode => _httpStatusCode;
   }
 }


### PR DESCRIPTION
## Goal

While looking for memory leaks in response to #99 I noticed that in the event that there is an exception while sending a report we continue trying to send the report when we should just stop trying to send the report as we will just get further exceptions if we continue the process. I also noticed that under high load the notify endpoint closes keep alive connections pretty aggressively which results in reports falling to send so I have disabled keep alive on the platforms where we can.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language