### PR TITLE
Include configuration package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## Unreleased
+
+* Include Configuration package with WebApi
+  | [martin308](https://github.com/martin308)
+  | [#105](https://github.com/bugsnag/bugsnag-dotnet/pull/105)
+
 ## 2.1.0 (2018-05-30)
 
 ### Enhancements

--- a/src/Bugsnag.AspNet.WebApi/Bugsnag.AspNet.WebApi.csproj
+++ b/src/Bugsnag.AspNet.WebApi/Bugsnag.AspNet.WebApi.csproj
@@ -8,9 +8,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
+    <ProjectReference Include="..\Bugsnag.ConfigurationSection\Bugsnag.ConfigurationSection.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="4.0.20505.0" />


### PR DESCRIPTION
Adds the configuration package as a dependency of the web api package so that people can use `*.config` files out of the box without having to add the additional package.