### PR TITLE
Allow fully qualified types to be provided in config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## Unreleased
 
+* Add additional method of specifying ignore classes to allow for providing fully qualified assembly names in config files.
+  | [martin308](https://github.com/martin308)
+  | [#109](https://github.com/bugsnag/bugsnag-dotnet/pull/109)
+
 * Include Configuration package with WebApi
   | [martin308](https://github.com/martin308)
   | [#105](https://github.com/bugsnag/bugsnag-dotnet/pull/105)

--- a/src/Bugsnag.ConfigurationSection/Configuration.cs
+++ b/src/Bugsnag.ConfigurationSection/Configuration.cs
@@ -207,7 +207,7 @@ namespace Bugsnag.ConfigurationSection
 
     private const string ignoreClasses = "ignoreClasses";
 
-    [ConfigurationProperty("ignoreClasses", IsRequired = false)]
+    [ConfigurationProperty(ignoreClasses, IsRequired = false)]
     private string InternalIgnoreClasses
     {
       get

--- a/src/Bugsnag.ConfigurationSection/Configuration.cs
+++ b/src/Bugsnag.ConfigurationSection/Configuration.cs
@@ -229,16 +229,69 @@ namespace Bugsnag.ConfigurationSection
     {
       get
       {
-        if (_ignoreClasses == null && InternalIgnoreClasses != null)
+        if (_ignoreClasses == null)
         {
-          _ignoreClasses = InternalIgnoreClasses
-            .Split(',')
-            .Select(c => Type.GetType(c))
-            .Where(t => t != null).ToArray();
+          _ignoreClasses = CompleteIgnoreClasses
+            .Select(t => Type.GetType(t))
+            .Where(c => c != null)
+            .ToArray();
         }
 
         return _ignoreClasses;
       }
+    }
+
+    private IEnumerable<string> CompleteIgnoreClasses
+    {
+      get
+      {
+        if (InternalIgnoreClasses != null)
+        {
+          foreach (var item in InternalIgnoreClasses.Split(','))
+          {
+            yield return item;
+          }
+        }
+
+        if (InternalExtendedIgnoreClasses.Count > 0)
+        {
+          foreach (ExtendedIgnoreClass item in InternalExtendedIgnoreClasses)
+          {
+            yield return item.Name;
+          }
+        }
+      }
+    }
+
+    private const string extendedIgnoreClasses = "assemblyQualifiedIgnoreClasses";
+
+    [ConfigurationProperty(extendedIgnoreClasses, IsRequired = false)]
+    private ExtendedIgnoreClassCollection InternalExtendedIgnoreClasses
+    {
+      get
+      {
+        return (ExtendedIgnoreClassCollection)this[extendedIgnoreClasses];
+      }
+    }
+
+    [ConfigurationCollection(typeof(ExtendedIgnoreClass), AddItemName = "class", CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    class ExtendedIgnoreClassCollection : ConfigurationElementCollection
+    {
+      protected override ConfigurationElement CreateNewElement()
+      {
+        return new ExtendedIgnoreClass();
+      }
+
+      protected override object GetElementKey(ConfigurationElement element)
+      {
+        return ((ExtendedIgnoreClass)element).Name;
+      }
+    }
+
+    class ExtendedIgnoreClass : ConfigurationElement
+    {
+      [ConfigurationProperty("name", IsRequired = true)]
+      public string Name => (string)this["name"];
     }
 
     private const string metadataFilters = "metadataFilters";

--- a/tests/Bugsnag.ConfigurationSection.Tests/Complete.config
+++ b/tests/Bugsnag.ConfigurationSection.Tests/Complete.config
@@ -21,6 +21,9 @@
     proxyPassword="password"
     sessionsEndpoint="https://www.bugsnag.com"
     maximumBreadcrumbs="30">
+    <assemblyQualifiedIgnoreClasses>
+      <class name="Xunit.FactAttribute, xunit.core" />
+    </assemblyQualifiedIgnoreClasses>
     <metadata>
       <item key="test" value="wow" />
     </metadata>

--- a/tests/Bugsnag.ConfigurationSection.Tests/CompleteTests.cs
+++ b/tests/Bugsnag.ConfigurationSection.Tests/CompleteTests.cs
@@ -70,7 +70,7 @@ namespace Bugsnag.ConfigurationSection.Tests
     [Fact]
     public void IgnoreClassesIsSet()
     {
-      Assert.Equal(new[] { typeof(NotImplementedException), typeof(DllNotFoundException) }, TestConfiguration.IgnoreClasses);
+      Assert.Equal(new[] { typeof(NotImplementedException), typeof(DllNotFoundException), typeof(FactAttribute) }, TestConfiguration.IgnoreClasses);
     }
 
     [Fact]

--- a/tests/Bugsnag.ConfigurationSection.Tests/DefaultTests.cs
+++ b/tests/Bugsnag.ConfigurationSection.Tests/DefaultTests.cs
@@ -62,9 +62,9 @@ namespace Bugsnag.ConfigurationSection.Tests
     }
 
     [Fact]
-    public void IgnoreClassesIsNull()
+    public void IgnoreClassesIsEmpty()
     {
-      Assert.Null(TestConfiguration.IgnoreClasses);
+      Assert.Empty(TestConfiguration.IgnoreClasses);
     }
 
     [Fact]


### PR DESCRIPTION
## Goal

Allow specifying any kind of exception to ignore in a `config` file. Right now exception types outside of `mscorlib` will not be resolved as you cannot specify the full assembly qualified name which requires the use of a comma which we currently use as a separator.

This adds an additional method of describing ignore classes in a `config` file.