### PR TITLE
Add CLR runtime version and framework description

### DIFF
--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -16,6 +16,9 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/Bugsnag/Payload/Device.cs
+++ b/src/Bugsnag/Payload/Device.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.InteropServices;
 
 namespace Bugsnag.Payload
 {
@@ -51,6 +52,11 @@ namespace Bugsnag.Payload
       get
       {
         var runtimeVersions = new Dictionary<string, string>();
+#if NET45
+        // The framework description is only available from .NET 4.5 onwards and will not return
+        // an accurate value for .NET Core until version 3.0 
+        runtimeVersions.AddToPayload("dotnet", RuntimeInformation.FrameworkDescription);
+#endif
 #if !NETSTANDARD1_3
         // The CLR version is available for all .NET framework versions and all .NET Core versions since 2.0
         runtimeVersions.AddToPayload("dotnetClr", Environment.Version.ToString());

--- a/src/Bugsnag/Payload/Device.cs
+++ b/src/Bugsnag/Payload/Device.cs
@@ -20,6 +20,7 @@ namespace Bugsnag.Payload
       this.AddToPayload("timezone", TimeZoneInfo.Local.DisplayName);
       this.AddToPayload("osName", OsName);
       this.AddToPayload("time", DateTime.UtcNow);
+      this.AddToPayload("runtimeVersions", RuntimeVersions);
     }
 
     /// <summary>
@@ -42,6 +43,19 @@ namespace Bugsnag.Payload
 #else
         return Environment.OSVersion.VersionString;
 #endif
+      }
+    }
+
+    private static Dictionary<string, string> RuntimeVersions
+    {
+      get
+      {
+        var runtimeVersions = new Dictionary<string, string>();
+#if !NETSTANDARD1_3
+        // The CLR version is available for all .NET framework versions and all .NET Core versions since 2.0
+        runtimeVersions.AddToPayload("dotnetClr", Environment.Version.ToString());
+#endif
+        return runtimeVersions;
       }
     }
   }

--- a/tests/Bugsnag.Tests/Payload/DeviceTests.cs
+++ b/tests/Bugsnag.Tests/Payload/DeviceTests.cs
@@ -22,7 +22,7 @@ namespace Bugsnag.Tests.Payload
     }
 
     [Fact]
-    public void InclidesTime()
+    public void IncludesTime()
     {
       var device = new Device("hostname");
       Assert.NotNull(device["time"]);

--- a/tests/Bugsnag.Tests/Payload/DeviceTests.cs
+++ b/tests/Bugsnag.Tests/Payload/DeviceTests.cs
@@ -1,4 +1,5 @@
 using Bugsnag.Payload;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Bugsnag.Tests.Payload
@@ -21,10 +22,18 @@ namespace Bugsnag.Tests.Payload
     }
 
     [Fact]
-    public void SpecifyTime()
+    public void InclidesTime()
     {
       var device = new Device("hostname");
       Assert.NotNull(device["time"]);
+    }
+
+    [Fact]
+    public void IncludesRuntimeVersions()
+    {
+      var device = new Device("hostname");
+      var runtimeVersions = (Dictionary<string, string>) device["runtimeVersions"];
+      Assert.NotNull(runtimeVersions["dotnetClr"]);
     }
 
     [Fact]

--- a/tests/Bugsnag.Tests/Payload/DeviceTests.cs
+++ b/tests/Bugsnag.Tests/Payload/DeviceTests.cs
@@ -33,6 +33,7 @@ namespace Bugsnag.Tests.Payload
     {
       var device = new Device("hostname");
       var runtimeVersions = (Dictionary<string, string>) device["runtimeVersions"];
+      Assert.NotNull(runtimeVersions["dotnet"]);
       Assert.NotNull(runtimeVersions["dotnetClr"]);
     }
 


### PR DESCRIPTION
## Goal

- Add the CLR runtime version to the device section of the payload. This will be added to reports for apps that support .NET Standard 2.0 and above, such as .NET Core 2.0 and above, or any version of the .NET Framework.
- Add the framework description. The framework description is only available for .NET 4.5 onwards and will not return does not return an accurate value for .NET Core [until version 3.0](https://github.com/dotnet/coreclr/issues/22844) so will not be set for .NET Core 1 and 2.

The `runtimeVersions` part of the report payload will look something like this:
```json
runtimeVersions {
  "dotnet": ".NET Framework 4.7.3416.0",
  "dotnetClr": "4.0.30319.42000"
}
``` 
## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
