### PR TITLE
Unobserved exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Changelog
 
 ### Bug fixes
 
-* Handle any exceptions raised when reading files for code segments 
+* Handle any exceptions raised when reading files for code segments.
   | [twometresteve](https://github.com/twometresteve)
   | [#123](https://github.com/bugsnag/bugsnag-dotnet/pull/123)
+
+* Account for process termination behavior when handling UnobservedTaskExceptions.
+  | [twometresteve](https://github.com/twometresteve)
+  | [#125](https://github.com/bugsnag/bugsnag-dotnet/pull/125)
 
 ## 2.2.0 (2018-07-19)
 

--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Bugsnag</PackageId>
     <Title>Bugsnag .NET Notifier</Title>
@@ -19,6 +19,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />

--- a/src/Bugsnag/UnhandledException.cs
+++ b/src/Bugsnag/UnhandledException.cs
@@ -74,12 +74,12 @@ namespace Bugsnag
 
     private void CurrentDomain_ProcessExit(object sender, EventArgs e)
     {
-      HandleEvent(null, _unobservedTerminates);
+      HandleEvent(null, true);
     }
 
     private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
     {
-      HandleEvent(e.Exception as Exception, !e.Observed);
+      HandleEvent(e.Exception as Exception, _unobservedTerminates);
     }
 
     [HandleProcessCorruptedStateExceptions]

--- a/src/Bugsnag/UnhandledException.cs
+++ b/src/Bugsnag/UnhandledException.cs
@@ -11,9 +11,11 @@ namespace Bugsnag
 
     private readonly object _currentClientLock = new object();
     private IClient _currentClient;
+    private bool _unobservedTerminates;
 
     private UnhandledException()
     {
+      _unobservedTerminates = DetermineUnobservedTerminates();
       AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
       AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
       TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
@@ -46,9 +48,33 @@ namespace Bugsnag
       }
     }
 
+    /// <summary>
+    /// Determines if an UnobservedTaskException leads to the process terminating, based on the target
+    /// framework and (when applicable) configuration.
+    /// </summary>
+    /// <returns></returns>
+    private bool DetermineUnobservedTerminates()
+    {
+#if NET35 || NET40
+      return true;
+#elif NET45
+      System.Xml.Linq.XElement configFile = System.Xml.Linq.XElement.Load(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile);
+      if (configFile != null)
+      {
+          // TODO Null check all the way down
+          Console.WriteLine(configFile.Element("runtime").Element("ThrowUnobservedTaskExceptions").Attribute("enabled").Value);
+      }
+#elif NETSTANDARD1_3 || NETSTANDARD2_0
+      // TODO SetupInformation does not exist in .NET Standard 1.3
+      // ConfigurationMAnager _might_ be an option in .NET Standard 2.0
+      //AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName
+      return false;
+#endif
+    }
+
     private void CurrentDomain_ProcessExit(object sender, EventArgs e)
     {
-      HandleEvent(null, true);
+      HandleEvent(null, _unobservedTerminates);
     }
 
     private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)

--- a/src/Bugsnag/UnhandledException.cs
+++ b/src/Bugsnag/UnhandledException.cs
@@ -57,25 +57,18 @@ namespace Bugsnag
     /// framework and (when applicable) configuration.
     /// </summary>
     /// <returns></returns>
-#if NET45
     private bool DetermineUnobservedTerminates()
     {
+#if NET45
       System.Xml.Linq.XElement configFile = System.Xml.Linq.XElement.Load(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile);
       var configValue = configFile?.Element("runtime")?.Element("ThrowUnobservedTaskExceptions")?.Attribute("enabled")?.Value;
       bool value;
       var success = bool.TryParse(configValue, out value);
       return success && value;
-    }
-#endif
-
-#if NETSTANDARD1_3 || NETSTANDARD2_0
-    private bool DetermineUnobservedTerminates()
-    {
-      //Console.WriteLine(System.Runtime.InteropServices.RuntimeEnvironment.SystemConfigurationFile);
-
+#else //NETSTANDARD1_3 || NETSTANDARD2_0
       return false;
-  }
 #endif
+    }
 
     private void CurrentDomain_ProcessExit(object sender, EventArgs e)
     {


### PR DESCRIPTION
## Goal

Correctly respond to UnobservedTaskExceptions, in terms of whether the process will be terminated.

## Design

- For .NET Framework versions prior to 4.5, the process will always terminate.
- For .NET Framework versions after 4.5, the default behavior is not to terminate, but can be configured to do so.  We therefore check for the `ThrowUnobservedTaskExceptions` configuration.
- For .NET Standard we will assume that the default behavior holds - not to terminate

## Tests

Tested with the standard regression tests, together with manual testing using the examples in the repository.

## Discussion

### Outstanding Questions

Assuming that the process will not terminate with .NET Standard is not ideal, as it could be configured to do so.  However, determining how to check the configuration in a portable way has proven troublesome and so we will address this for concrete examples on a case-by-case basis should the need arise.  The default behavior is likely to prevail and is catered for, in any case.

### Linked issues

Fixes #116 