### PR TITLE
Removed WPF from UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -57,27 +57,7 @@ If you are targeting .NET 3.5 please follow the directions provided in the [docu
 
 ##### WPF applications
 
-There is no dedicated WPF Nuget package yet, so this will just require [updating](https://docs.microsoft.com/en-us/nuget/consume-packages/reinstalling-and-updating-packages) your [Bugsnag](https://www.nuget.org/packages/Bugsnag/) Nuget package to version 2.0.0. If you are using your `App.config` to configure Bugsnag then you will also need to add the [Bugsnag.ConfigurationSection](https://www.nuget.org/packages/Bugsnag.ConfigurationSection/) package.
-
-The Bugsnag config section in your `App.config` will need to be changed slightly.
-
-```diff
- <configuration>
-   <configSections>
--    <section name="bugsnagConfig" type="Bugsnag.ConfigurationStorage.ConfigSection, Bugsnag" />
-+    <section name="bugsnag" type="Bugsnag.ConfigurationSection.Configuration, Bugsnag.ConfigurationSection" />
-   </configSections>
--  <bugsnagConfig apiKey="your-api-key-goes-here" />
-+  <bugsnag apiKey="your-api-key-goes-here" />
- </configuration>
-```
-
-In your `OnStartup` method in `App.xaml.cs`, remove the call to start the `WPFClient`. And create an instance of the Bugsnag client. You can store this to use as a singleton.
-
-```diff
-- WPFClient.Start();
-+ var client = new Bugsnag.Client(Bugsnag.ConfigurationSection.Configuration.Settings);
-```
+The latest supported `bugsnag-dotnet` library for WPF applications is [v1.4.0](https://github.com/bugsnag/bugsnag-dotnet/releases/tag/v1.4.0). Please refer to the [Bugsnag WPF application docs](https://docs.bugsnag.com/platforms/dotnet/wpf/) for more details on how to install and configure Bugsnag in your WPF application.
 
 ##### Other applications
 


### PR DESCRIPTION
## Goal
WPF applications should use v1.4.0, as per the docs. The upgrade guide should not contain any instruction for WPF applications.