### PR TITLE
PLAT-5359] Assume default behaviour for UnobservedTaskExceptions when app.config does not exist

### DIFF
--- a/src/Bugsnag/UnhandledException.cs
+++ b/src/Bugsnag/UnhandledException.cs
@@ -58,7 +58,10 @@ namespace Bugsnag
 #if NET35 || NET40
       return true;
 #elif NET45
-      System.Xml.Linq.XElement configFile = System.Xml.Linq.XElement.Load(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile);
+      System.Xml.Linq.XElement configFile = null;
+      if(System.IO.File.Exists(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile))
+        configFile = System.Xml.Linq.XElement.Load(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile); 
+
       var configValue = configFile?.Element("runtime")?.Element("ThrowUnobservedTaskExceptions")?.Attribute("enabled")?.Value;
       bool value;
       var success = bool.TryParse(configValue, out value);


### PR DESCRIPTION
## Goal

for .NET 4.5 Bugsnag attempts to load the `App.config` file to read the value of the `ThrowUnobservedTaskExceptions` element and this crashes with a `FileNotFoundException` if there is no `App.config` file. This PR guards against `App.config` not existing

## Design

Make sure that the file exists before loading, and assume the default behaviour (UnobservedTaskExceptions do not terminate the process) if the config file doesn't exist.

## Changeset

Added a `File.Exists` check to `UnhandledException#DetermineUnobservedTerminates`

## Testing

Ran the unit tests and tested manually using the example apps in the repository