### PR TITLE
Fix crash when stackframe method is null

### DIFF
--- a/src/Bugsnag/Middleware.cs
+++ b/src/Bugsnag/Middleware.cs
@@ -78,14 +78,17 @@ namespace Bugsnag
         {
           foreach (var stackTraceLine in exception.StackTrace)
           {
-            foreach (var @namespace in report.Configuration.ProjectNamespaces)
+            if (!Polyfills.String.IsNullOrWhiteSpace(stackTraceLine.MethodName))
             {
-              if (stackTraceLine.MethodName.StartsWith(@namespace))
+              foreach (var @namespace in report.Configuration.ProjectNamespaces)
               {
-                stackTraceLine.InProject = true;
-                break;
+                if (stackTraceLine.MethodName.StartsWith(@namespace))
+                {
+                  stackTraceLine.InProject = true;
+                  break;
+                }
               }
-            }
+            }            
           }
         }
       }

--- a/src/Bugsnag/Payload/StackTraceLine.cs
+++ b/src/Bugsnag/Payload/StackTraceLine.cs
@@ -53,7 +53,7 @@ namespace Bugsnag.Payload
         {
           // if the exception has not come from a stack trace then we need to
           // skip the frames that originate from inside the notifier code base
-          var currentStackFrameIsNotify = stackFrame.MethodName.StartsWith("Bugsnag.Client.Notify");
+          var currentStackFrameIsNotify = !Polyfills.String.IsNullOrWhiteSpace(stackFrame.MethodName) && stackFrame.MethodName.StartsWith("Bugsnag.Client.Notify");
           seenBugsnagFrames = seenBugsnagFrames || currentStackFrameIsNotify;
           if (!seenBugsnagFrames || currentStackFrameIsNotify)
           {

--- a/tests/Bugsnag.Tests/MiddlewareTests.cs
+++ b/tests/Bugsnag.Tests/MiddlewareTests.cs
@@ -157,6 +157,14 @@ namespace Bugsnag.Tests
             ShouldBeMarkedAsInProject = true }
         }
       };
+      yield return new object[] {
+        new string[] { "Bugsnag.Code", "Bugsnag.Assets" },
+        new StackTraceInProjectTestCase[] {
+          new StackTraceInProjectTestCase {
+            MethodName = null,
+            ShouldBeMarkedAsInProject = false }
+        }
+      };
     }
   }
 }


### PR DESCRIPTION
## Goal

Fixes a crash in the notifier when a Stackframe reports a `null` method.

## Design

It's possible that `StackFrame.GetMethod()` may return `null` in some circumstances, so we should guard against this in our code

## Changeset

Added null checks wherever code accesses `StackTraceLine.Methodname`

## Testing

Tested manually by manipulating stacktraces in the debugger to cause a crash.