### PR TITLE
Yousif/remove breadcrumb limit

### DIFF
--- a/src/Bugsnag/Payload/Breadcrumb.cs
+++ b/src/Bugsnag/Payload/Breadcrumb.cs
@@ -8,9 +8,7 @@ namespace Bugsnag.Payload
   /// </summary>
   public class Breadcrumb : Dictionary<string, object>
   {
-    private const int MaximumNameLength = 30;
     private const string UndefinedName = "Breadcrumb";
-    private const int MaximumMetadataCharacterCount = 1024;
 
     /// <summary>
     /// Build a new breadcrumb from an error report. This is used to attach a previously occurring exception to the
@@ -48,7 +46,6 @@ namespace Bugsnag.Payload
     public Breadcrumb(string name, BreadcrumbType type, IDictionary<string, string> metadata)
     {
       if (name == null) name = UndefinedName;
-      if (name.Length > MaximumNameLength) name = name.Substring(0, MaximumNameLength);
 
       this.AddToPayload("name", name);
       this.AddToPayload("timestamp", DateTime.UtcNow);

--- a/tests/Bugsnag.Tests/Payload/BreadcrumbTests.cs
+++ b/tests/Bugsnag.Tests/Payload/BreadcrumbTests.cs
@@ -42,15 +42,5 @@ namespace Bugsnag.Tests.Payload
 
       Assert.NotNull(breadcrumb.Name);
     }
-
-    [Fact]
-    public void LongNamesAreTrimmed()
-    {
-      var name = new String('a', 500);
-
-      var breadcrumb = new Breadcrumb(name, BreadcrumbType.Manual);
-
-      Assert.Equal(name.Substring(0, 30), breadcrumb.Name);
-    }
   }
 }


### PR DESCRIPTION
## Goal

Remove the 30 character limit on breadcrumb names and accompanying unit test

## Testing

Tested manually by leaving breadcrumbs with names > 30 characters and checking that names were not truncated in the Dashboard