### PR TITLE
Fix .NET Core 1.1 example

### DIFF
--- a/examples/netcore11-console/Program.cs
+++ b/examples/netcore11-console/Program.cs
@@ -23,6 +23,9 @@ namespace netcore11_console
       {
         client.Notify(ex);
       }
+
+      Console.WriteLine("Press any key to exit...");
+      Console.ReadKey();
     }
   }
 }


### PR DESCRIPTION
## Goal

Updates the .NET Core 1.1 example Console app to ensure the app stays alive long enough for the report to be sent. 

Looks like this is due to a limitation of .NET Core 1.1. Delivery is done on a background thread, and although this is dequeued immediately the console app is terminated before the background thread has finished sending the report. This is not the case in .NET Core 2.0.

As .NET Core 1.1 is EOL and not widely used I don't think this is worth investigating further, and we should simply prevent the console app from exiting immediately. 

## Design

Adds a `Console.ReadKey()` to the example to ensure the app stays alive long enough for the report to be sent

## Testing

Tested manually running the example app both from within Visual Studio and using the dotnet CLI.