### PR TITLE
Switch to snupkg package format and publish symbols to nuget.org

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ deploy:
   - provider: NuGet
     api_key:
       secure: MALWFhc9/aJSnKQhjY1OID0nl5LZpcWpP1vYAmTDQxhNkE41Y2Sft0zR1EOk6Nw3 
-    skip_symbols: false
-    artifact: /.*\.nupkg/
+    skip_symbols: true
+    artifact: /.*(\.|\.s)nupkg/
     on:
       appveyor_repo_tag: true
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ deploy:
   - provider: NuGet
     api_key:
       secure: MALWFhc9/aJSnKQhjY1OID0nl5LZpcWpP1vYAmTDQxhNkE41Y2Sft0zR1EOk6Nw3 
-    skip_symbols: true
+    skip_symbols: false
+    symbol_server: https://www.nuget.org/api/v2/symbolpackage
     artifact: /.*(\.|\.s)nupkg/
     on:
       appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ after_build:
   - ps: 7z a build\bugsnag.zip build\Release\**\Bugsnag*.dll build\Release\**\Bugsnag*.pdb
 test: off
 artifacts:
-  - path: 'build\packages\*.nupkg'
+  - path: 'build\packages\*.*nupkg'
   - path: 'build\bugsnag.zip'
 deploy:
   - provider: NuGet

--- a/build.cake
+++ b/build.cake
@@ -53,6 +53,7 @@ Task("Pack")
         .WithTarget("pack")
         .SetConfiguration(configuration)
         .WithProperty("IncludeSymbols", "true")
+        .WithProperty("SymbolPackageFormat", "snupkg")
         .WithProperty("GenerateDocumentationFile", "true")
         .WithProperty("PackageOutputPath", MakeAbsolute(nugetPackageOutput).FullPath));
   });


### PR DESCRIPTION
## Goal
Currently Appveyor attempts to upload the `nupkg` build artifacts to `nuget.org` and the `.symbols.nupkg` artifacts to the 3rd party symbol server `nuget.symbsrc.net`, which is no longer maintained. NuGet now supports publishing symbol packages directly to NuGet, using the new `snupkg` package format.

## Design

Updates the build to create NuGet symbol packages using the new `.snupkg` format rather than the now legacy `.symbols.nupkg` format, and configures Appveyor publish these to `nuget.org` rather than the 3rd-party `smbsrc.net`. 
