### PR TITLE
[PLAT-8150] Fix empty bugsnag.zip build artefact

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,5 @@
 <Project>
   <PropertyGroup>
     <OutputPath>$(BaseOutputPath)</OutputPath>
-	<AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Bugsnag.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,4 @@
 ﻿<Project>
-
-  <Import Project="..\Directory.Build.props"/>
-
   <PropertyGroup>
     <Authors>snmaynard kattrali martin308</Authors>
     <Version></Version>
@@ -15,5 +12,7 @@
     <LangVersion>7.1</LangVersion>
     <WarningsAsErrors />
     <NoWarn>1591</NoWarn>
+	<AssemblyOriginatorKeyFile>$(MSBuildStartupDirectory)\Bugsnag.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 </Project>

--- a/tests/Directory.build.props
+++ b/tests/Directory.build.props
@@ -1,4 +1,5 @@
 ﻿<Project>
+  <Import Project="..\Directory.Build.props"/>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
## Goal

As part of #151 the strong naming signing build properties were added to the root `Directory.build.props` which was then imported into `src/Directory.build.props`. 

However the root props also contains a `BaseOutputPath` property so this altered the output path for all of the project builds, so the post-build ZIP command was unable to locate the assemblies, leading to an empty `bugsnag.zip` artefact being uploaded to GitHub

## Design

Moved strong naming config out of the root props so that the `BaseOutputPath` is no longer imported by all projects. Also had to tweak `test/Directory.build.props` to ensure the tests preserved the same output path as before

## Testing

Manually tested build output against v2.2.3 to ensure output path was reverted and manually tested ZIP command to ensure that assemblies are picked up. Also manually verified that all packaged assemblies except `Bugsnag.AspNet.Core` still have a valid strong-name signature using `sn.exe`