### PR TITLE
Update deprecated and vulnerable packages

### DIFF
--- a/src/Bugsnag.AspNet.Core/Bugsnag.AspNet.Core.csproj
+++ b/src/Bugsnag.AspNet.Core/Bugsnag.AspNet.Core.csproj
@@ -8,18 +8,16 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.2" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Bugsnag.AspNet.WebApi/Bugsnag.AspNet.WebApi.csproj
+++ b/src/Bugsnag.AspNet.WebApi/Bugsnag.AspNet.WebApi.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
     <ProjectReference Include="..\Bugsnag.ConfigurationSection\Bugsnag.ConfigurationSection.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.0" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
   </ItemGroup>
 </Project>

--- a/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
@@ -7,8 +7,8 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <LangVersion>7.1</LangVersion>
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
@@ -11,7 +11,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bugsnag.AspNet.Core\Bugsnag.AspNet.Core.csproj" />

--- a/tests/Bugsnag.AspNet.Core.Tests/WebHostTests.cs
+++ b/tests/Bugsnag.AspNet.Core.Tests/WebHostTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Bugsnag.AspNet.Core.Tests
@@ -10,7 +11,7 @@ namespace Bugsnag.AspNet.Core.Tests
   public class WebHostTests
   {
     [Fact]
-    public async void TestWithNoExceptions()
+    public async Task TestWithNoExceptions()
     {
       var builder = new WebHostBuilder()
         .ConfigureServices(services => services.AddBugsnag(config => { config.ApiKey = "123456"; }))
@@ -28,7 +29,7 @@ namespace Bugsnag.AspNet.Core.Tests
     }
 
     [Fact]
-    public async void TestWithDeveloperExceptionPage()
+    public async Task TestWithDeveloperExceptionPage()
     {
       var bugsnag = new Bugsnag.Tests.TestServer();
       bugsnag.Start();

--- a/tests/Bugsnag.AspNet.Tests/Bugsnag.AspNet.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Tests/Bugsnag.AspNet.Tests.csproj
@@ -11,7 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bugsnag\Bugsnag.csproj" />

--- a/tests/Bugsnag.AspNet.Tests/Bugsnag.AspNet.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Tests/Bugsnag.AspNet.Tests.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/tests/Bugsnag.AspNet.Tests/Bugsnag.AspNet.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Tests/Bugsnag.AspNet.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
+++ b/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
+++ b/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
@@ -9,7 +9,10 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bugsnag.AspNet.WebApi\Bugsnag.AspNet.WebApi.csproj" />

--- a/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
+++ b/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
@@ -6,7 +6,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.0" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
+++ b/tests/Bugsnag.AspNet.WebApi.Tests/Bugsnag.AspNet.WebApi.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Bugsnag.AspNet.WebApi.Tests/WebHostTests.cs
+++ b/tests/Bugsnag.AspNet.WebApi.Tests/WebHostTests.cs
@@ -2,6 +2,7 @@ using Bugsnag.Tests;
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web.Http;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace Bugsnag.AspNet.WebApi.Tests
     }
 
     [Fact]
-    public async void Test()
+    public async Task Test()
     {
       var bugsnagServer = new TestServer();
 

--- a/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
+++ b/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
+++ b/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
+++ b/tests/Bugsnag.ConfigurationSection.Tests/Bugsnag.ConfigurationSection.Tests.csproj
@@ -11,7 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bugsnag.ConfigurationSection\Bugsnag.ConfigurationSection.csproj" />

--- a/tests/Bugsnag.Tests.Server/Bugsnag.Tests.Server.csproj
+++ b/tests/Bugsnag.Tests.Server/Bugsnag.Tests.Server.csproj
@@ -6,7 +6,7 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/tests/Bugsnag.Tests/Bugsnag.Tests.csproj
+++ b/tests/Bugsnag.Tests/Bugsnag.Tests.csproj
@@ -9,7 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bugsnag\Bugsnag.csproj" />

--- a/tests/Bugsnag.Tests/Bugsnag.Tests.csproj
+++ b/tests/Bugsnag.Tests/Bugsnag.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
     <LangVersion>7.1</LangVersion>
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Bugsnag.Tests/Bugsnag.Tests.csproj
+++ b/tests/Bugsnag.Tests/Bugsnag.Tests.csproj
@@ -7,7 +7,7 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/tests/Bugsnag.Tests/ClientTests.cs
+++ b/tests/Bugsnag.Tests/ClientTests.cs
@@ -10,7 +10,7 @@ namespace Bugsnag.Tests
   public class ClientTests
   {
     [Fact]
-    public async void TestThrownException()
+    public async Task TestThrownException()
     {
       var server = new TestServer();
 

--- a/tests/Bugsnag.Tests/SessionTrackingTests.cs
+++ b/tests/Bugsnag.Tests/SessionTrackingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Bugsnag.Tests
@@ -15,7 +16,7 @@ namespace Bugsnag.Tests
     }
 
     [Fact]
-    public async void CurrentSessionCanBeSet()
+    public async Task CurrentSessionCanBeSet()
     {
       var server = new TestServer();
 
@@ -33,7 +34,7 @@ namespace Bugsnag.Tests
     }
 
     [Fact]
-    public async void EmptySessionsPayloadsAreNotSent()
+    public async Task EmptySessionsPayloadsAreNotSent()
     {
       var server = new TestServer();
 

--- a/tests/Bugsnag.Tests/ThreadQueueDeliveryTests.cs
+++ b/tests/Bugsnag.Tests/ThreadQueueDeliveryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Bugsnag.Tests
@@ -9,7 +10,7 @@ namespace Bugsnag.Tests
   public class ThreadQueueDeliveryTests
   {
     [Fact]
-    public async void Test()
+    public async Task Test()
     {
       var numberOfRequests = 500;
 

--- a/tests/Bugsnag.Tests/WebRequestTests.cs
+++ b/tests/Bugsnag.Tests/WebRequestTests.cs
@@ -9,7 +9,7 @@ namespace Bugsnag.Tests
   public class WebRequestTests
   {
     [Fact]
-    public async void Test()
+    public async Task Test()
     {
       var numerOfRequests = 1;
       var server = new TestServer();


### PR DESCRIPTION
## Goal

Update deprecated/vulnerable dependencies across all projects (except `System.Net.Http`, which will be tackled separately)

Bumping xunit also required dropping `netcoreapp3.1` as a test target, as well as some small changes to async unit tests.

## Testing

Covered by CI