### PR TITLE
Add net6.0 target framework for Bugsnag and Bugsnag.AspNet.Core

### DIFF
--- a/src/Bugsnag.AspNet.Core/Bugsnag.AspNet.Core.csproj
+++ b/src/Bugsnag.AspNet.Core/Bugsnag.AspNet.Core.csproj
@@ -3,16 +3,19 @@
     <PackageId>Bugsnag.AspNet.Core</PackageId>
     <Title>Bugsnag .NET ASP.NET Core Notifier</Title>
     <Description>The Bugsnag Notifier for ASP.NET Core gives you instant notification of exceptions thrown from your ASP.NET Core applications. Any uncaught exceptions will trigger a notification to be sent to your Bugsnag project.</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 	<SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />

--- a/src/Bugsnag.AspNet.Mvc/Bugsnag.AspNet.Mvc.csproj
+++ b/src/Bugsnag.AspNet.Mvc/Bugsnag.AspNet.Mvc.csproj
@@ -8,14 +8,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Bugsnag.AspNet\Bugsnag.AspNet.csproj" />
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
+
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Abstractions" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+
+
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Bugsnag.AspNet.WebApi/Bugsnag.AspNet.WebApi.csproj
+++ b/src/Bugsnag.AspNet.WebApi/Bugsnag.AspNet.WebApi.csproj
@@ -6,11 +6,6 @@
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
     <ProjectReference Include="..\Bugsnag.ConfigurationSection\Bugsnag.ConfigurationSection.csproj" />
   </ItemGroup>

--- a/src/Bugsnag.AspNet/Bugsnag.AspNet.csproj
+++ b/src/Bugsnag.AspNet/Bugsnag.AspNet.csproj
@@ -10,10 +10,7 @@
     <ProjectReference Include="..\Bugsnag.ConfigurationSection\Bugsnag.ConfigurationSection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/Bugsnag.ConfigurationSection/Bugsnag.ConfigurationSection.csproj
+++ b/src/Bugsnag.ConfigurationSection/Bugsnag.ConfigurationSection.csproj
@@ -9,8 +9,6 @@
     <ProjectReference Include="..\Bugsnag\Bugsnag.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
 </Project>

--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -6,18 +6,6 @@
     <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Bugsnag/Bugsnag.csproj
+++ b/src/Bugsnag/Bugsnag.csproj
@@ -3,7 +3,7 @@
     <PackageId>Bugsnag</PackageId>
     <Title>Bugsnag .NET Notifier</Title>
     <Description>The Bugsnag Notifier for .NET gives you instant notification of exceptions thrown from your .NET applications. Any uncaught exceptions will trigger a notification to be sent to your Bugsnag project.</Description>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />

--- a/src/Bugsnag/UnhandledException.cs
+++ b/src/Bugsnag/UnhandledException.cs
@@ -79,7 +79,9 @@ namespace Bugsnag
       HandleEvent(e.Exception as Exception, _unobservedTerminates && !e.Observed);
     }
 
+#if NET462 || NETSTANDARD2_0
     [HandleProcessCorruptedStateExceptions]
+#endif
     private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
       HandleEvent(e.ExceptionObject as Exception, e.IsTerminating);

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <Authors>snmaynard kattrali martin308</Authors>
     <Version></Version>
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/bugsnag/bugsnag-dotnet</PackageProjectUrl>
     <PackageIcon>bugsnag.png</PackageIcon>
-    <DisableImplicitFrameworkReferences Condition="'$(TargetFramework)' != 'netstandard1.3' AND '$(TargetFramework)' != 'netstandard2.0'">true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition="'$(TargetFramework)' == 'net462'">true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7.1</LangVersion>
     <NoWarn>1591</NoWarn>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -7,7 +7,6 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/bugsnag/bugsnag-dotnet</PackageProjectUrl>
     <PackageIcon>bugsnag.png</PackageIcon>
-    <DisableImplicitFrameworkReferences Condition="'$(TargetFramework)' == 'net462'">true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7.1</LangVersion>
     <NoWarn>1591</NoWarn>

--- a/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
+++ b/tests/Bugsnag.AspNet.Core.Tests/Bugsnag.AspNet.Core.Tests.csproj
@@ -7,7 +7,6 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -15,6 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.36" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.14" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bugsnag.AspNet.Core\Bugsnag.AspNet.Core.csproj" />


### PR DESCRIPTION
## Goal

Adds a net6.0 target framework for the Bugsnag and Bugsnag.AspNet.Core packages and updates project references accordingly.

## Design

Many of the package references (nuget dependencies) for these projects are provided by the .NET platform/framework and only require a nuget package reference when targeting netstandard. 

By targeting net6.0 and restricting these package references to the netstandard2.0 target, consuming projects on .NET 6+ will not need to pull in unnecessary nuget dependencies for packages that are provided by the platform/runtime, while projects that still need to use the netstandard2.0 dll can continue to do so.

In addition, I've removed the `DisableImplicitFrameworkReferences` config and removed unnecessary framework references from the project files. This was an outdated approach from the early days of netstandard that is no longer required/recommended for netstandard2.0 (see https://github.com/dotnet/standard/blob/release/2.0.0/docs/faq.md#should-i-reference-the-meta-package-or-should-i-reference-individual-packages).

## Testing

Tested manually