### PR TITLE
Ensure delivery is only configured once for request scoped clients

### DIFF
--- a/src/Bugsnag.AspNet/Client.cs
+++ b/src/Bugsnag.AspNet/Client.cs
@@ -10,6 +10,13 @@ namespace Bugsnag.AspNet
 
     private static IClient _globalClient;
 
+    static Client()
+    {
+      // configure the delivery once here to avoid creating a new HttpClient
+      // for every request when a proxy is set in the configuration.
+      DefaultDelivery.Instance.Configure(ConfigurationSection.Configuration.Settings);
+    }
+
     public static IClient Current
     {
       get
@@ -27,7 +34,7 @@ namespace Bugsnag.AspNet
           {
             // this is the first time a client has been requested for this
             // request scope, so create one and attach it to the request
-            var requestScopedClient = new Bugsnag.Client(ConfigurationSection.Configuration.Settings);
+            var requestScopedClient = new Bugsnag.Client(ConfigurationSection.Configuration.Settings, DefaultDelivery.Instance);
             HttpContext.Current.Items[HttpContextItemsKey] = requestScopedClient;
             return requestScopedClient;
           }
@@ -39,7 +46,7 @@ namespace Bugsnag.AspNet
           {
             if (_globalClient == null)
             {
-              _globalClient = new Bugsnag.Client(ConfigurationSection.Configuration.Settings);
+              _globalClient = new Bugsnag.Client(ConfigurationSection.Configuration.Settings, DefaultDelivery.Instance);
             }
           }
 

--- a/src/Bugsnag/Client.cs
+++ b/src/Bugsnag/Client.cs
@@ -47,9 +47,19 @@ namespace Bugsnag
     /// Constructs a client with the default storage and delivery classes.
     /// </summary>
     /// <param name="configuration"></param>
-    public Client(IConfiguration configuration) : this(configuration, DefaultDelivery.Instance, new Breadcrumbs(configuration), new SessionTracker(configuration))
+    public Client(IConfiguration configuration) : this(configuration, DefaultDelivery.Instance)
     {
       DefaultDelivery.Instance.Configure(configuration);
+    }
+
+    /// <summary>
+    /// Constructs a client with the specified configuration and delivery classes.
+    /// </summary>
+    /// <param name="configuration"></param>
+    /// <param name="delivery"></param>
+    public Client(IConfiguration configuration, IDelivery delivery) : this(configuration, delivery, new Breadcrumbs(configuration), new SessionTracker(configuration))
+    {
+
     }
 
     /// <summary>


### PR DESCRIPTION
## Goal

Configuring a proxy requires creating a new `HttpClient` because the `HttpClientHandler` (which handles the proxy settings) cannot be modified once the `HttpClient` is created.

This PR improves the handling of the delivery configuration for request scoped clients to ensure that `HttpClient` instances are not unnecessarily disposed and recreated for each request when a proxy is specified.

## Design

Added a new client constructor overload to support creating clients with a preconfigured delivery instance, and updated the logic in `Bugsnag.AspNet` and `Bugsnag.AspNet.Core` to use this and configure delivery once on startup

## Testing

Tested manually