### PR TITLE
Make MetadataFilters case insensitive

### DIFF
--- a/src/Bugsnag/Serializer.cs
+++ b/src/Bugsnag/Serializer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace Bugsnag
     public static string SerializeObject(object obj, string[] filters)
     {
       var parsedFilters = filters != null ?
-        filters.ToDictionary(m => m, m => true) :
+        filters.ToDictionary(m => m, m => true, StringComparer.OrdinalIgnoreCase) :
         new Dictionary<string, bool>();
 
       try

--- a/tests/Bugsnag.Tests/SerializerTests.cs
+++ b/tests/Bugsnag.Tests/SerializerTests.cs
@@ -87,6 +87,7 @@ namespace Bugsnag.Tests
       yield return new object[] { new FilterableTestObject { { "password", "password" } }, null, 0 };
       yield return new object[] { new FilterableTestObject { { "username", "password" } }, new string[] { "password" }, 0 };
       yield return new object[] { new FilterableTestObject { { "password", "password" }, { "credit_card_number", "number" } }, new string[] { "password", "credit_card_number" }, 2 };
+      yield return new object[] { new FilterableTestObject { { "Password", "password" }, { "Credit_Card_Number", "number" } }, new string[] { "password", "credit_card_number" }, 2 };
     }
   }
 }


### PR DESCRIPTION
## Goal

Make `MetadataFilters` case insensitive, as per the notifier spec for redacted keys. 

## Design

Filters are converted to a dictionary in the serializer, so this just needed updating to use case insensitive key comparison.

## Testing

Added a new unit test case to verify that filtering is case insensitive