### PR TITLE
Fix serialization error when serializing exceptions

### DIFF
--- a/src/Bugsnag/SimpleJson.cs
+++ b/src/Bugsnag/SimpleJson.cs
@@ -1548,6 +1548,11 @@ namespace SimpleJson
                 output = ((Guid)input).ToString("D");
             else if (input is Uri)
                 output = input.ToString();
+            else if (typeof(System.Reflection.MethodBase).IsAssignableFrom(input.GetType()))
+            {
+              // MethodBase (i.e. TargetSite in Exceptions) cannot be serialized, so ignore
+              output = null;
+            }
             else
             {
                 Enum inputEnum = input as Enum;

--- a/tests/Bugsnag.Tests/SerializerTests.cs
+++ b/tests/Bugsnag.Tests/SerializerTests.cs
@@ -58,6 +58,20 @@ namespace Bugsnag.Tests
       Assert.NotNull(json);
     }
 
+    [Fact]
+    public void CanSerializeException()
+    {
+      try
+      {
+        throw new System.Exception("Serialize me");
+      }
+      catch (System.Exception exception)
+      {
+        var json = Serializer.SerializeObject(exception);
+        Assert.NotNull(json);
+      }
+    }
+
     private class Circular
     {
       public string Name { get; set; }


### PR DESCRIPTION
## Goal

Fixes a crash in the serializer when attempting to serialize an `Exception` object attached to an event as metadata.

This happens because `MethodBase` (the `TargetSite` property of `Exception`s) is not serializable.

## Design

The Serializer now serializes values of type `MethodBase` to null since they cannot be serialized - to remove the property entirely would require some significant refactoring due to how the serialization code is structured

## Testing

Added a new unit test case, plus manual testing.