### PR TITLE
Fix device OS name and model detection on iOS/Android (.NET 6+)

### DIFF
--- a/src/Bugsnag/Payload/Device.cs
+++ b/src/Bugsnag/Payload/Device.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 
 namespace Bugsnag.Payload
 {
@@ -19,6 +20,9 @@ namespace Bugsnag.Payload
       this.AddToPayload("locale", CultureInfo.CurrentCulture.ToString());
       this.AddToPayload("timezone", TimeZoneInfo.Local.DisplayName);
       this.AddToPayload("osName", OsName);
+      var model = Model;
+      if (model != null)
+        this.AddToPayload("model", model);
       this.AddToPayload("time", DateTime.UtcNow);
     }
 
@@ -33,11 +37,73 @@ namespace Bugsnag.Payload
       }
     }
 
+    private static string Model
+    {
+      get
+      {
+#if NET6_0_OR_GREATER
+        if (OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsTvOS())
+        {
+          try
+          {
+            var uiDeviceType = Type.GetType("UIKit.UIDevice, Microsoft.iOS");
+            if (uiDeviceType != null)
+            {
+              var currentDevice = uiDeviceType.GetProperty("CurrentDevice", BindingFlags.Public | BindingFlags.Static)?.GetValue(null);
+              if (currentDevice != null)
+                return uiDeviceType.GetProperty("Model", BindingFlags.Public | BindingFlags.Instance)?.GetValue(currentDevice) as string;
+            }
+          }
+          catch
+          {
+            // Reflection may fail in trimmed/AOT builds
+          }
+        }
+        else if (OperatingSystem.IsAndroid())
+        {
+          try
+          {
+            var buildType = Type.GetType("Android.OS.Build, Mono.Android");
+            if (buildType != null)
+              return buildType.GetProperty("Model", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as string;
+          }
+          catch
+          {
+            // Reflection may fail in trimmed/AOT builds
+          }
+        }
+#endif
+        return null;
+      }
+    }
+
     private static string OsName
     {
       get
       {
-#if NETSTANDARD2_0
+#if NET6_0_OR_GREATER
+        var version = Environment.OSVersion.Version;
+        string name;
+        if (OperatingSystem.IsIOS())
+          name = "iOS";
+        else if (OperatingSystem.IsMacCatalyst())
+          name = "macOS (Mac Catalyst)";
+        else if (OperatingSystem.IsTvOS())
+          name = "tvOS";
+        else if (OperatingSystem.IsWatchOS())
+          name = "watchOS";
+        else if (OperatingSystem.IsAndroid())
+          name = "Android";
+        else if (OperatingSystem.IsMacOS())
+          name = "macOS";
+        else if (OperatingSystem.IsWindows())
+          name = "Windows";
+        else if (OperatingSystem.IsLinux())
+          name = "Linux";
+        else
+          return System.Runtime.InteropServices.RuntimeInformation.OSDescription;
+        return $"{name} {version}";
+#elif NETSTANDARD2_0
         return System.Runtime.InteropServices.RuntimeInformation.OSDescription;
 #else
         return Environment.OSVersion.VersionString;


### PR DESCRIPTION
## Summary
- **OS name**: On .NET 6+ mobile platforms, `Environment.OSVersion.VersionString` reports `"Unix <version>"` instead of the actual platform. Now uses `System.OperatingSystem` checks to report the correct name (e.g. `"iOS 26.3.1"` instead of `"Unix 26.3.1"`). Also covers Android, macOS, tvOS, watchOS, Mac Catalyst, Windows, and Linux.
- **Device model**: Adds a `model` field to the device payload by resolving the device model via reflection — `UIKit.UIDevice.CurrentDevice.Model` on iOS (returns `"iPhone"` / `"iPad"`) and `Android.OS.Build.Model` on Android — without requiring platform-specific target frameworks. Gracefully falls back to `null` (field omitted) on unsupported platforms or in trimmed/AOT builds.

## Test plan
- [ ] Verify on a .NET iOS project that `osName` reports `"iOS <version>"` instead of `"Unix <version>"`
- [ ] Verify on a .NET iOS project that `model` reports `"iPhone"` or `"iPad"`
- [ ] Verify on .NET desktop/server that existing behavior is unchanged
- [ ] Verify the library builds cleanly for all three TFMs (`net462`, `netstandard2.0`, `net6.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)